### PR TITLE
feat: replace Sarvam AI label with GitHub star button in Settings About

### DIFF
--- a/src/renderer/modals/SettingsModal.css
+++ b/src/renderer/modals/SettingsModal.css
@@ -280,6 +280,29 @@
   font-size: 12px;
 }
 
+.github-star-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--vibrant-label);
+  background: var(--glass-bg);
+  border: 1px solid var(--border-glass);
+  backdrop-filter: var(--liquid-blur);
+  padding: 3px 10px;
+  border-radius: var(--radius-s);
+  text-decoration: none;
+  transition: var(--liquid-morph);
+  cursor: pointer;
+}
+
+.github-star-btn:hover {
+  background: var(--glass-bg-hover);
+  border-color: var(--border-blue);
+  color: var(--vibrant-primary);
+  box-shadow: 0 0 8px var(--internal-glow);
+}
+
 /* API Key Settings Styling */
 .api-input-wrapper {
   margin-top: 8px;

--- a/src/renderer/modals/SettingsModal.tsx
+++ b/src/renderer/modals/SettingsModal.tsx
@@ -243,7 +243,16 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
             <h3 className="section-title">About</h3>
             <div className="about-info">
               <span>SyncSpeak v2.0.0</span>
-              <span className="about-muted">Powered by Sarvam AI</span>
+              <a
+                className="github-star-btn"
+                href="#"
+                onClick={e => { e.preventDefault(); open('https://github.com/Soumyadipgithub/SyncSpeak') }}
+              >
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+                Give us a star 🌟
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!-- ⚠️  TARGET BRANCH: This PR must target `develop`, not `main`.
     ⚠️  BRANCH NAME:  Must follow the format in CONTRIBUTING.md:
          feat/issue-42-short-description
          fix/issue-7-brief-name
          docs/update-pipeline-diagram
     CI will block the PR automatically if the branch name is wrong. -->

## What this PR does

Replaces the static "Powered by Sarvam AI" label in Settings → About with a Liquid Glass styled GitHub star button. Clicking it opens the SyncSpeak GitHub repo in the system default browser using `@tauri-apps/plugin-shell`'s `open()` (required because Tauri's WebView ignores `target="_blank"`). The `shell:allow-open` capability was already present so no Rust or config changes were needed.

## How to test

1. Run `npm run dev` and open the Settings modal
2. Navigate to the About section — verify the GitHub star button renders in place of the old label
3. Click the button — verify it opens `https://github.com/Soumyadipgithub/SyncSpeak` in your default browser
4. Hover over the button — verify the blue border glow transition appears

## Checklist

- [x] Branch targets `develop` (not `main`)
- [x] Branch name follows the `<type>/issue-<n>-<description>` convention
- [x] Read [CLAUDE.md](../CLAUDE.md) before making changes
- [x] Behaviour is unchanged or the change is intentional and described above
- [x] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback
- [x] Glass design rules followed (no solid backgrounds, no Tailwind)
- [x] No hardcoded API keys, paths, or credentials
- [x] Tested manually with `npm run dev`

## Screenshots (if UI changed)
<img width="579" height="491" alt="image" src="https://github.com/user-attachments/assets/9c5f59d3-4056-4bd2-bc8c-7b0229cc3afb" />

Before: `Powered by Sarvam AI` (plain muted text)
After: Liquid Glass pill button with GitHub icon + "Give us a star 🌟"