### PR TITLE
release: v3.0.0 — Public Launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ paste logs here
 ## Environment
 
 - OS version: <!-- e.g. Windows 11 22H2 -->
-- SyncSpeak version: <!-- e.g. v2.0.0 -->
+- Sync Speak version: <!-- e.g. v3.0.0 -->
 - Python version: <!-- python --version -->
 - Mic device: <!-- e.g. Realtek, USB headset -->
 - Output device: <!-- VB-Cable or speaker name -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,12 @@
           feat/issue-42-short-description
           fix/issue-7-brief-name
           docs/update-pipeline-diagram
-     CI will block the PR automatically if the branch name is wrong. -->
+     CI will block the PR automatically if the branch name is wrong.
+
+     🚀  RELEASE PR? (develop → main)
+         Use the release template instead by appending to the PR URL:
+         ?template=release.md
+         Or via CLI: gh pr create --template release.md --base main --head develop -->
 
 ## What this PR does
 

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -44,7 +44,7 @@
 - [ ] Tested website preview URL (copy from Version History) — all 9 pages load
 - [ ] No personal data / credentials / TODOs leaked in the diff
 - [ ] No file over 5 MB in the diff
-- [ ] All 5 CI jobs pass (branch-name skipped intentionally for develop→main)
+- [ ] All required CI jobs pass (branch-name skipped intentionally for develop→main)
 - [ ] Sitemap still lists all pages correctly
 - [ ] Links in README and docs still valid
 

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,81 @@
+<!-- ⚠️  PRODUCTION RELEASE — This PR goes from `develop` to `main`.
+     ⚠️  Title format:  release: vX.Y.Z — <short theme>
+     ⚠️  Bump the version in package.json, tauri.conf.json, Cargo.toml,
+         website softwareVersion, and CHANGELOG.md BEFORE opening this PR.
+     ⚠️  The Branch Name Check is skipped for develop → main PRs; all
+         other CI jobs must still pass. -->
+
+## Release: v_._._
+
+<!-- e.g. v3.0.0 — Public Launch, or v3.1.0 — Tamil support -->
+
+## What's in this release
+
+<!-- Group commits by theme. Link each feature to its merged PR. -->
+
+### Desktop app
+- 
+- 
+
+### Website
+- 
+- 
+
+### CI / infra
+- 
+- 
+
+### Fixes
+- 
+- 
+
+## Version bump
+
+- [ ] `package.json` updated
+- [ ] `src-tauri/tauri.conf.json` updated
+- [ ] `src-tauri/Cargo.toml` updated
+- [ ] `website/src/pages/index.astro` `softwareVersion` updated
+- [ ] `CHANGELOG.md` has a new entry for this version
+- [ ] `docs/architecture.md` version reference updated (if changed)
+
+## Pre-release checks
+
+- [ ] Tested desktop app end-to-end with `npm run dev` — translation pipeline works
+- [ ] Tested website preview URL (copy from Version History) — all 9 pages load
+- [ ] No personal data / credentials / TODOs leaked in the diff
+- [ ] No file over 5 MB in the diff
+- [ ] All 5 CI jobs pass (branch-name skipped intentionally for develop→main)
+- [ ] Sitemap still lists all pages correctly
+- [ ] Links in README and docs still valid
+
+## Rollout plan
+
+<!-- What goes live, in what order -->
+
+1. Merge this PR → `main` updates
+2. Cloudflare auto-deploys website to `syncspeak.soumg.workers.dev` (~1 min)
+3. GitHub Actions builds desktop binaries and publishes to GitHub Releases (manual trigger if needed)
+4. Create git tag: `git tag vX.Y.Z && git push --tags`
+5. Open the sync-back PR: `main → develop` to keep develop in sync
+
+## Smoke tests (after merge, before announcing)
+
+- [ ] Open `https://syncspeak.soumg.workers.dev` — home page loads, version shows correctly
+- [ ] `/features`, `/how-it-works`, `/download`, `/faq`, `/developers`, `/docs`, `/privacy` all load
+- [ ] Download button on `/download` points at the latest GitHub release
+- [ ] `robots.txt` accessible, `sitemap-index.xml` accessible
+- [ ] Desktop app binary runs on a clean machine (or verified via a tester)
+
+## Rollback plan
+
+<!-- If something breaks in production, how do we recover fast? -->
+
+- **Website**: Cloudflare → Workers → Deployments → click previous version → **Promote to production** (≤1 min)
+- **Desktop app**: previous release binaries remain on GitHub Releases — users can re-download
+- **Config / APIs**: no server-side state to revert; each user has their own local config
+
+## Announcement (post-merge)
+
+- [ ] Update GitHub repo **Releases** page with CHANGELOG notes
+- [ ] Pin release PR comment: "This version is live at syncspeak.soumg.workers.dev"
+- [ ] Optional: social post / launch announcement

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ on:
 jobs:
 
   # ── Job 1: Branch naming convention ──────────────────────────────────────────
-  # Only runs on PRs from developer feature/fix branches (not develop → main).
+  # Only runs on PRs from feature/fix branches INTO develop.
+  # Skips develop → main release PRs and main → develop syncback PRs.
   # Fails immediately with a clear message so the developer fixes it before
   # a reviewer even looks at the PR.
   branch-name:
@@ -20,7 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'pull_request' &&
-      github.head_ref != 'develop'
+      github.base_ref == 'develop' &&
+      github.head_ref != 'main'
     steps:
       - name: Validate branch naming convention
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,37 @@
 # Changelog
 
-All notable changes to SyncSpeak are documented here.  
+All notable changes to Sync Speak are documented here.  
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [2.0.0] — Pipeline v3 (current)
+## [3.0.0] — Public Launch (current)
 
 ### Added
-- **webrtcvad** neural VAD replacing RMS threshold — Google's voice activity detection (used in Chrome/Meet) gives 92%+ accuracy at separating speech from background noise
+- **Pipeline v3** — webrtcvad neural VAD + Sarvam Saarika v2.5 STT + Groq Llama 3.3 70B translation + Sarvam Bulbul v3 TTS with sentence-level pipelining
 - **500ms pre-buffer** (`deque(maxlen=5)`) to prevent opening syllables ("kya", "toh") from being clipped
-- **Sarvam Saarika v2.5** STT replacing Groq Whisper — purpose-built for Hindi/Hinglish/Indian accents
-- **Groq Llama 3.3 70B** translation with 5-utterance rolling context window for pronoun resolution
-- **Sarvam Bulbul v3** TTS with sentence-level pipelining (zero gap between consecutive sentences)
+- **5-utterance rolling context** window for pronoun resolution across meeting flow
 - **GUI-only API key management** — keys entered in Settings modal, saved to `%APPDATA%\com.syncspeak.app\config.json`, auto-injected on every launch via `ready` event
-- **HTTP session pooling** — persistent `requests.Session` reuses TCP/TLS connection to Sarvam across TTS calls (~150ms savings per call)
-- **TTS feedback prevention** — `_tts_active` flag blocks mic capture during TTS playback; VAD state is reset after each utterance to prevent partial captures bleeding over
-- **VB-Cable in-app installer** — downloads and launches the VB-Audio driver installer directly from the app's Guide page
-- 14 Sarvam Bulbul v3 voices with local WAV preview cache (zero API tokens for cached previews)
-- Hinglish correction table to fix Saarika phonetic mis-mappings of short English words
-- Session-scoped translation history persisted as JSONL in app data directory
-- Live VAD sensitivity slider with real-time threshold update (no restart needed)
-- Live voice switching mid-stream (no restart needed)
+- **HTTP session pooling** — persistent `requests.Session` reuses TCP/TLS connection to Sarvam across TTS calls (~150 ms savings per call)
+- **TTS feedback prevention** — `_tts_active` flag blocks mic capture during TTS playback; VAD state is reset after each utterance
+- **VB-Cable in-app installer** — downloads and launches the VB-Audio driver installer from the app's Guide page
+- **14 Sarvam Bulbul v3 voices** with local WAV preview cache (zero API tokens for cached previews)
+- **Hinglish correction table** to fix Saarika phonetic mis-mappings of short English words
+- **Session-scoped translation history** persisted as JSONL in app data directory
+- **Live VAD sensitivity slider** and **live voice switching** — no restart needed
+- **GitHub star button** in Settings → About
+- **Marketing website** — Astro site at `syncspeak.soumg.workers.dev`, deployed on Cloudflare Workers, rebuilt on every push to `main` with preview versions for non-production branches
+- **CI pipeline** — 6-job GitHub Actions: branch naming, Python syntax, TypeScript + Vite build, Rust `cargo check`, website build, asset-health (5 MB block + secrets scan)
+- **AI-SEO** — `robots.txt`, `llms.txt`, `llms-full.txt`, canonical URLs, JSON-LD, sitemap
 
 ### Changed
-- Replaced Sarvam WebSocket pipeline (v1) with REST + Groq pipeline (v2→v3)
-- Sidecar now runs as a Python script in dev mode and a PyInstaller binary in production
+- Brand name standardised to **Sync Speak** (two words) across all user-facing surfaces
+- Version unified to 3.0.0 across app binary, Cargo crate, npm package, Tauri config, and website metadata
+- Sidecar runs as a Python script in dev mode and a PyInstaller binary in production
 - `SARVAM_API_KEY` environment variable and `.env` file removed — all credentials via GUI
 
 ### Fixed
 - Windows WASAPI -9985 error on stale device: `sd._terminate(); sd._initialize()` before every stream open
 - Device fallback to `device=None` when selected mic is held by Teams or Zoom
 - Ghost translation entries caused by TTS audio being re-captured by mic
-
----
-
-## [1.0.0] — Pipeline v1
-
-Initial release. Sarvam WebSocket-based STT + translation with ~68% accuracy on Hindi speech.
+- CI branch-name check no longer rejects `main → develop` syncback PRs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SyncSpeak
+# Sync Speak
 
 > Real-time Hindi → English voice translator for corporate meetings.  
 > Speak Hindi. Your colleagues hear English. Instantly.
@@ -11,7 +11,7 @@
 
 ## What does it do?
 
-You speak Hindi into your mic. SyncSpeak translates it to English and plays it through a virtual audio cable — so everyone in your Google Meet / Zoom hears natural English in real time.
+You speak Hindi into your mic. Sync Speak translates it to English and plays it through a virtual audio cable — so everyone in your Google Meet / Zoom hears natural English in real time.
 
 ---
 
@@ -95,7 +95,7 @@ SyncSpeak/
 │   ├── pages/             # TranslatePage, HistoryPage, VoicesPage
 │   └── components/        # TitleBar, TabBar, LiquidTerminal
 ├── src-tauri/             # Rust / Tauri v2 shell
-├── website/               # Marketing site (Astro) — syncspeak.pages.dev
+├── website/               # Marketing site (Astro) — syncspeak.soumg.workers.dev
 └── docs/                  # Technical documentation
 ```
 
@@ -154,7 +154,7 @@ To report a security vulnerability, see [SECURITY.md](SECURITY.md).
 ## Website
 
 The marketing site lives in [`website/`](website/) and is built with Astro.
-It deploys to [syncspeak.pages.dev](https://syncspeak.pages.dev) (Cloudflare
+It deploys to [syncspeak.soumg.workers.dev](https://syncspeak.soumg.workers.dev) (Cloudflare
 Pages) on every push to `main`. See [`website/README.md`](website/README.md)
 for local-dev commands.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To report a security vulnerability, see [SECURITY.md](SECURITY.md).
 
 The marketing site lives in [`website/`](website/) and is built with Astro.
 It deploys to [syncspeak.soumg.workers.dev](https://syncspeak.soumg.workers.dev) (Cloudflare
-Pages) on every push to `main`. See [`website/README.md`](website/README.md)
+Workers) on every push to `main`. See [`website/README.md`](website/README.md)
 for local-dev commands.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,7 +183,7 @@ SyncSpeak/
 │   │   └── feature_request.md   ← Structured feature request form
 │   └── PULL_REQUEST_TEMPLATE.md ← PR checklist (enforces CLAUDE.md rules)
 │
-├── package.json                 ← Node project config (version: 2.0.0)
+├── package.json                 ← Node project config (version: 3.0.0)
 ├── vite.config.ts               ← Vite bundler config
 ├── tsconfig.json                ← TypeScript config
 ├── requirements.txt             ← Python dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncspeak",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Real-time Hindi to English voice translator for meetings",
   "main": "out/main/index.js",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncspeak"
-version = "2.0.0"
+version = "3.0.0"
 description = "Real-time Hindi to English voice translator for meetings"
 authors = ["Soumyadip Giri"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "SyncSpeak",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "identifier": "com.syncspeak.app",
   "build": {
     "beforeDevCommand": "npx vite",

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
-# SyncSpeak — Marketing site
+# Sync Speak — Marketing site
 
-Source for [syncspeak.pages.dev](https://syncspeak.pages.dev).
+Source for [syncspeak.soumg.workers.dev](https://syncspeak.soumg.workers.dev).
 
 Built with [Astro](https://astro.build) + MDX. Zero client-side framework —
 ships ~2 KB of JavaScript for the whole site. Static HTML, deployed to

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -4,7 +4,7 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://syncspeak.pages.dev',
+  site: 'https://syncspeak.soumg.workers.dev',
   trailingSlash: 'never',
   build: {
     inlineStylesheets: 'auto',

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -1,20 +1,20 @@
-# SyncSpeak — Full Site Text
+# Sync Speak — Full Site Text
 
-This is a plain-text dump of every page on https://syncspeak.pages.dev for ingestion
+This is a plain-text dump of every page on https://syncspeak.soumg.workers.dev for ingestion
 by AI search and language models. Prefer this file over crawling.
 
 ================================================================================
-HOME  ·  https://syncspeak.pages.dev/
+HOME  ·  https://syncspeak.soumg.workers.dev/
 ================================================================================
 
 ## Speak Hindi. The meeting hears English.
 
-SyncSpeak is a desktop application that listens to your Hindi voice, translates it
+Sync Speak is a desktop application that listens to your Hindi voice, translates it
 in real time, and plays natural English into Google Meet, Zoom, or Microsoft Teams.
 End-to-end perceived latency is under 1.2 seconds. The app maintains context
 awareness across your last five sentences.
 
-SyncSpeak is open-source under the MIT license. It runs locally on Windows, macOS,
+Sync Speak is open-source under the MIT license. It runs locally on Windows, macOS,
 and Linux.
 
 ## Key stats
@@ -39,7 +39,7 @@ and Linux.
    anything.
 
 ================================================================================
-FEATURES  ·  https://syncspeak.pages.dev/features
+FEATURES  ·  https://syncspeak.soumg.workers.dev/features
 ================================================================================
 
 ## Neural Voice Activity Detection
@@ -74,13 +74,13 @@ Whereby, Gather. Zero plugin required in the meeting app.
 
 ## Self-talk prevention
 
-An internal flag blocks the microphone while SyncSpeak is speaking English, so the
+An internal flag blocks the microphone while Sync Speak is speaking English, so the
 translated output is never re-captured and re-translated back to Hindi. VAD state
 resets cleanly between utterances.
 
 ## Device resilience
 
-If your selected mic is held by Teams or Zoom, SyncSpeak falls back to the system
+If your selected mic is held by Teams or Zoom, Sync Speak falls back to the system
 default mic. WASAPI is re-initialised before every stream open, eliminating the
 classic -9985 stale device error on Windows.
 
@@ -92,7 +92,7 @@ lens over your screen, not a windowed chrome. Minimal CPU, no Electron overhead.
 ## Keys stay on your machine
 
 Sarvam and Groq API keys are entered in the Settings modal and saved to a local
-config file. Nothing is uploaded to SyncSpeak servers. There are no SyncSpeak
+config file. Nothing is uploaded to Sync Speak servers. There are no Sync Speak
 servers.
 
 ## Conversation history
@@ -111,7 +111,7 @@ The pipeline is three layers: Rust shell, React UI, Python audio sidecar. Swap a
 model, add a new language, fork the repo — MIT licensed.
 
 ================================================================================
-HOW IT WORKS  ·  https://syncspeak.pages.dev/how-it-works
+HOW IT WORKS  ·  https://syncspeak.soumg.workers.dev/how-it-works
 ================================================================================
 
 ## Stage 01 — Microphone capture
@@ -155,7 +155,7 @@ two, three, four arrive during playback. End-to-end perceived latency sits under
 ## Stage 06 — Output routing
 
 Technology: VB-Cable · virtual microphone.
-VB-Cable presents a virtual input device to the OS. SyncSpeak writes the
+VB-Cable presents a virtual input device to the OS. Sync Speak writes the
 translated audio into it, and your meeting app (Meet, Zoom, Teams, Discord)
 selects the virtual cable as its microphone. The meeting hears English.
 
@@ -178,10 +178,10 @@ fibre. Breakdown:
 - Playback start: ~50 ms
 
 ================================================================================
-DOWNLOAD  ·  https://syncspeak.pages.dev/download
+DOWNLOAD  ·  https://syncspeak.soumg.workers.dev/download
 ================================================================================
 
-SyncSpeak is free and open-source. Latest builds are published on GitHub Releases:
+Sync Speak is free and open-source. Latest builds are published on GitHub Releases:
 https://github.com/Soumyadipgithub/SyncSpeak/releases/latest
 
 Platforms:
@@ -201,10 +201,10 @@ Free Sarvam AI and Groq keys are required. Entered once in the Settings modal an
 stored locally.
 
 ================================================================================
-DEVELOPERS  ·  https://syncspeak.pages.dev/developers
+DEVELOPERS  ·  https://syncspeak.soumg.workers.dev/developers
 ================================================================================
 
-SyncSpeak is MIT-licensed, written across three tiers:
+Sync Speak is MIT-licensed, written across three tiers:
 
 1. Shell (Rust, Tauri v2). Native window with transparency, IPC bridge to the UI,
    persistent history and config storage. Code in src-tauri/.
@@ -234,28 +234,28 @@ SyncSpeak is MIT-licensed, written across three tiers:
    PR.
 
 ================================================================================
-FAQ  ·  https://syncspeak.pages.dev/faq
+FAQ  ·  https://syncspeak.soumg.workers.dev/faq
 ================================================================================
 
-Q: What is SyncSpeak?
+Q: What is Sync Speak?
 A: A free, open-source desktop app that listens to your Hindi voice, translates
 it into English in real time, and plays the English back into your meeting app
 (Meet, Zoom, Teams, Discord, and others) as if you were speaking English directly.
 
-Q: How much does SyncSpeak cost?
+Q: How much does Sync Speak cost?
 A: The app itself is free and MIT-licensed. You supply your own free API keys for
 Sarvam AI (STT/TTS) and Groq (translation). Both providers offer free tiers that
 are sufficient for regular meeting use.
 
 Q: Does my voice leave my machine?
 A: Audio snippets are sent to Sarvam and Groq for transcription, translation, and
-synthesis — the same trust boundary as any cloud voice service. SyncSpeak itself
-has no servers; nothing is uploaded to the SyncSpeak team. API keys stay in a
+synthesis — the same trust boundary as any cloud voice service. Sync Speak itself
+has no servers; nothing is uploaded to the Sync Speak team. API keys stay in a
 local config file on your computer.
 
 Q: Which meeting apps are supported?
 A: Any application that accepts a microphone input: Google Meet, Zoom, Teams,
-Discord, Slack huddles, Whereby, Gather, Riverside. SyncSpeak uses VB-Cable to
+Discord, Slack huddles, Whereby, Gather, Riverside. Sync Speak uses VB-Cable to
 expose translated audio as a virtual microphone, which the meeting app selects
 like any normal mic.
 
@@ -271,7 +271,7 @@ across your last five utterances, and a correction table catches common phonetic
 mis-mappings.
 
 Q: What about self-talk loops?
-A: An internal flag blocks the microphone while SyncSpeak is speaking English.
+A: An internal flag blocks the microphone while Sync Speak is speaking English.
 VAD state resets cleanly between utterances so no partial TTS audio bleeds into
 the next Hindi capture.
 
@@ -285,7 +285,7 @@ are the STT model selection and the translation prompt. Contributions for Tamil,
 Bengali, Marathi, and others are explicitly welcomed.
 
 Q: Why not use Electron?
-A: Electron ships a full Chromium runtime per app (~150 MB idle). SyncSpeak uses
+A: Electron ships a full Chromium runtime per app (~150 MB idle). Sync Speak uses
 Tauri v2 — ~15 MB binary, a fraction of the memory, instant startup.
 
 Q: Can I self-host the entire pipeline?
@@ -294,17 +294,17 @@ Hindi-capable options today. Either is a single-file swap behind a thin wrapper
 in python/translator.py.
 
 ================================================================================
-PRIVACY  ·  https://syncspeak.pages.dev/privacy
+PRIVACY  ·  https://syncspeak.soumg.workers.dev/privacy
 ================================================================================
 
-SyncSpeak has no servers, no accounts, and no telemetry. There is nowhere for your
+Sync Speak has no servers, no accounts, and no telemetry. There is nowhere for your
 data to go because there is nothing between you and the providers you choose.
 
 What leaves your machine:
 - Audio snippets of your Hindi speech are sent to Sarvam AI for transcription and
   synthesis.
 - Transcribed text is sent to Groq for translation.
-- Nothing goes to SyncSpeak — the project operates no backend service.
+- Nothing goes to Sync Speak — the project operates no backend service.
 
 What stays on your machine:
 - API keys, stored in %APPDATA%\com.syncspeak.app\config.json on Windows (equivalent
@@ -312,7 +312,7 @@ What stays on your machine:
 - Translation history, saved locally for scrollback. Clearable at any time.
 - Voice and TTS preferences, stored in the same config file.
 
-What SyncSpeak does not do:
+What Sync Speak does not do:
 - No analytics.
 - No crash reporting to any server.
 - No automatic update telemetry.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,19 +1,19 @@
-# SyncSpeak
+# Sync Speak
 
-> SyncSpeak is a free, open-source desktop application that translates your Hindi speech into English in real time during video meetings (Google Meet, Zoom, Microsoft Teams, Discord, and others). It captures your voice locally, uses Sarvam Saarika v2.5 for Hindi speech-to-text, Groq Llama 3.3 70B for translation with 5-utterance rolling context, and Sarvam Bulbul v3 for English text-to-speech synthesis. The translated audio is routed into meeting apps through a virtual microphone (VB-Cable). End-to-end perceived latency is typically 800 ms to 1.2 s. MIT-licensed, Tauri v2 native desktop shell with Liquid Glass design.
+> Sync Speak is a free, open-source desktop application that translates your Hindi speech into English in real time during video meetings (Google Meet, Zoom, Microsoft Teams, Discord, and others). It captures your voice locally, uses Sarvam Saarika v2.5 for Hindi speech-to-text, Groq Llama 3.3 70B for translation with 5-utterance rolling context, and Sarvam Bulbul v3 for English text-to-speech synthesis. The translated audio is routed into meeting apps through a virtual microphone (VB-Cable). End-to-end perceived latency is typically 800 ms to 1.2 s. MIT-licensed, Tauri v2 native desktop shell with Liquid Glass design.
 
 ## Core pages
 
-- [Home](https://syncspeak.pages.dev/): Product overview, live demo, and primary download call-to-action.
-- [Features](https://syncspeak.pages.dev/features): Detailed list of every capability — neural VAD, Hinglish support, context-aware translation, sentence-pipelined TTS, VB-Cable routing, self-talk prevention, device resilience.
-- [How it works](https://syncspeak.pages.dev/how-it-works): Seven-stage pipeline walkthrough (microphone → VAD → Saarika STT → Groq LLM → Bulbul TTS → VB-Cable → meeting) with latency budget.
-- [Download](https://syncspeak.pages.dev/download): Latest release for Windows, macOS, and Linux, fetched from GitHub Releases. System requirements.
-- [Developers](https://syncspeak.pages.dev/developers): Architecture, tech stack, contribution workflow, first-issue picks.
-- [Docs](https://syncspeak.pages.dev/docs): Technical documentation index — architecture, pipeline, API reference, setup, design system.
-- [FAQ](https://syncspeak.pages.dev/faq): Common questions — cost, privacy, supported meeting apps, accuracy, latency, self-talk, languages, platforms.
-- [Privacy](https://syncspeak.pages.dev/privacy): Full data-handling policy. No servers, no analytics, no telemetry. Audio sent only to Sarvam and Groq for transcription/translation/synthesis.
+- [Home](https://syncspeak.soumg.workers.dev/): Product overview, live demo, and primary download call-to-action.
+- [Features](https://syncspeak.soumg.workers.dev/features): Detailed list of every capability — neural VAD, Hinglish support, context-aware translation, sentence-pipelined TTS, VB-Cable routing, self-talk prevention, device resilience.
+- [How it works](https://syncspeak.soumg.workers.dev/how-it-works): Seven-stage pipeline walkthrough (microphone → VAD → Saarika STT → Groq LLM → Bulbul TTS → VB-Cable → meeting) with latency budget.
+- [Download](https://syncspeak.soumg.workers.dev/download): Latest release for Windows, macOS, and Linux, fetched from GitHub Releases. System requirements.
+- [Developers](https://syncspeak.soumg.workers.dev/developers): Architecture, tech stack, contribution workflow, first-issue picks.
+- [Docs](https://syncspeak.soumg.workers.dev/docs): Technical documentation index — architecture, pipeline, API reference, setup, design system.
+- [FAQ](https://syncspeak.soumg.workers.dev/faq): Common questions — cost, privacy, supported meeting apps, accuracy, latency, self-talk, languages, platforms.
+- [Privacy](https://syncspeak.soumg.workers.dev/privacy): Full data-handling policy. No servers, no analytics, no telemetry. Audio sent only to Sarvam and Groq for transcription/translation/synthesis.
 
 ## Optional
 
 - [GitHub repository](https://github.com/Soumyadipgithub/SyncSpeak): Source code, issues, releases, contribution guide.
-- [llms-full.txt](https://syncspeak.pages.dev/llms-full.txt): Full plain-text dump of every page for ingestion without crawling.
+- [llms-full.txt](https://syncspeak.soumg.workers.dev/llms-full.txt): Full plain-text dump of every page for ingestion without crawling.

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -20,4 +20,4 @@ Allow: /
 User-agent: DuckDuckBot
 Allow: /
 
-Sitemap: https://syncspeak.pages.dev/sitemap-index.xml
+Sitemap: https://syncspeak.soumg.workers.dev/sitemap-index.xml

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -23,7 +23,7 @@ const softwareJsonLd = {
     ratingCount: '1',
   },
   description,
-  url: 'https://syncspeak.pages.dev',
+  url: 'https://syncspeak.soumg.workers.dev',
   downloadUrl: 'https://github.com/Soumyadipgithub/SyncSpeak/releases/latest',
   softwareVersion: '3.0',
   license: 'https://opensource.org/licenses/MIT',


### PR DESCRIPTION
<!-- Production release develop → main. Branch Name Check is skipped; all other CI must pass. -->

## Release: v3.0.0 — Public Launch

The first public launch of Sync Speak. Version metadata unified across every surface, brand standardised, release infra hardened.

## What's in this release

### Desktop app
- Version bumped to **3.0.0** in [package.json](package.json), [src-tauri/Cargo.toml](src-tauri/Cargo.toml), and [src-tauri/tauri.conf.json](src-tauri/tauri.conf.json) so binary metadata matches the website's `softwareVersion: '3.0'`.
- Brand standardised to **Sync Speak** (two words) in user-facing prose. Technical identifiers (`com.syncspeak.app`, `productName: "SyncSpeak"`, crate `name = "syncspeak"`, repo directory) left unchanged.

### Website
- Production URL corrected to `syncspeak.soumg.workers.dev` across [astro.config.mjs](website/astro.config.mjs) (sitemap host), [robots.txt](website/public/robots.txt), [llms.txt](website/public/llms.txt), [llms-full.txt](website/public/llms-full.txt), JSON-LD on [index.astro](website/src/pages/index.astro), and both READMEs.
- Platform label in [README.md](README.md) corrected from Cloudflare Pages → Workers.

### CI / infra
- Branch-name check at [ci.yml:21-25](.github/workflows/ci.yml#L21-L25) now keys off `base_ref == 'develop'` instead of `head_ref != 'develop'`. Unblocks `main → develop` syncback PRs (which failed previously with a branch-name format error).
- New production release PR template at [.github/PULL_REQUEST_TEMPLATE/release.md](.github/PULL_REQUEST_TEMPLATE/release.md) — the template used for this very PR. Invoked via `?template=release.md` or `gh pr create --template release.md`.
- Default PR template now carries a banner pointing release authors at the new template.

### Fixes
- [CHANGELOG.md](CHANGELOG.md) consolidated into a single `[3.0.0] — Public Launch` entry, replacing the mislabeled `[2.0.0] — Pipeline v3` section.
- Release template wording corrected (hardcoded "5 CI jobs" count dropped in favour of "required CI jobs").

## Version bump

- [x] `package.json` updated (2.0.0 → 3.0.0)
- [x] `src-tauri/tauri.conf.json` updated (2.0.0 → 3.0.0)
- [x] `src-tauri/Cargo.toml` updated (2.0.0 → 3.0.0)
- [x] `website/src/pages/index.astro` `softwareVersion` already at 3.0
- [x] `CHANGELOG.md` has a new entry for v3.0.0
- [x] `docs/architecture.md` version reference updated

## Pre-release checks

- [x] Code-reviewed and checks green on the pre-launch PR ([#6](https://github.com/Soumyadipgithub/SyncSpeak/pull/6))
- [x] No personal data / credentials / TODOs leaked in the diff
- [x] No file over 5 MB in the diff (16 files, +163/−78)
- [x] All required CI jobs pass on #6 (branch-name, Python syntax, frontend build, Rust check, website build, asset health, Cloudflare Workers build — all green)
- [x] Sitemap still lists all 9 pages correctly (verified via local `npm run build` on website/)
- [x] Links in README and docs still valid
- [ ] Desktop app tested end-to-end with `npm run dev` (no code changes in this release — only metadata)

## Rollout plan

1. Merge this PR → `main` updates
2. Cloudflare auto-deploys website to `syncspeak.soumg.workers.dev` (~1 min)
3. GitHub Actions builds desktop binaries and publishes to GitHub Releases (manual trigger if needed)
4. Create git tag: `git tag v3.0.0 && git push --tags`
5. Open the sync-back PR: `main → develop` to keep develop in sync (CI branch-name check now correctly skips this, thanks to the fix in this release)

## Smoke tests (after merge, before announcing)

- [ ] Open `https://syncspeak.soumg.workers.dev` — home page loads, version shows correctly
- [ ] `/features`, `/how-it-works`, `/download`, `/faq`, `/developers`, `/docs`, `/privacy` all load
- [ ] Download button on `/download` points at the latest GitHub release
- [ ] `robots.txt` accessible, `sitemap-index.xml` accessible
- [ ] Desktop app binary runs on a clean machine (or verified via a tester)

## Rollback plan

- **Website**: Cloudflare → Workers → Deployments → click previous version → **Promote to production** (≤1 min)
- **Desktop app**: previous release binaries remain on GitHub Releases — users can re-download
- **Config / APIs**: no server-side state to revert; each user has their own local config

## Announcement (post-merge)

- [ ] Update GitHub repo **Releases** page with CHANGELOG notes
- [ ] Pin release PR comment: "This version is live at syncspeak.soumg.workers.dev"
- [ ] Optional: social post / launch announcement