### PR TITLE
ci: add auto-syncback workflow with safe auto-merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/syncback.md
+++ b/.github/PULL_REQUEST_TEMPLATE/syncback.md
@@ -1,0 +1,11 @@
+<!-- Automated syncback opened by .github/workflows/auto-syncback.yml.
+     If opening manually: gh pr create --template syncback.md --base develop --head main -->
+
+## Syncback: `main` → `develop`
+
+Realigns `develop` with `main`. If you're reading this in an open PR, it means **main has file changes develop doesn't** (hotfix, docs patch, or something committed directly to main). Empty-diff syncs auto-merge and you'd just see a "PR merged" notification instead.
+
+- [ ] Diff looks correct for the direct-to-main change
+- [ ] No merge conflicts
+
+Click **Merge pull request** — done.

--- a/.github/workflows/auto-syncback.yml
+++ b/.github/workflows/auto-syncback.yml
@@ -1,0 +1,147 @@
+name: Auto Syncback main → develop
+
+# Opens a PR to pull main's merge commits back into develop after a release.
+# GitHub's merge buttons (merge-commit / squash / rebase) always leave main 1 commit
+# ahead of develop because the merge commit lives only on main. Without this workflow,
+# that gap widens every release and every new feature branch you cut from develop
+# inherits stale history. This workflow closes the gap automatically.
+#
+# ──────────────────────────────────────────────────────────────────────────────
+# ONE-TIME SETUP (do this once when you install this workflow):
+#
+#   Settings → Actions → General → Workflow permissions
+#     • Select "Read and write permissions"
+#     • Tick "Allow GitHub Actions to create and approve pull requests"
+#
+# Without the above, the workflow fails when it tries to open the sync PR.
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# NOTE ON CI: PRs opened by GITHUB_TOKEN do not trigger other workflows
+# (GitHub's built-in anti-loop protection). If you want CI to run on the sync
+# PR, close + reopen it once — that re-triggers checks under your user account.
+# For a typical "0 files changed" sync PR, CI isn't strictly needed anyway.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:   # manual re-run from the Actions tab if ever needed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+
+  syncback:
+    name: Open syncback PR
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Check whether sync is actually needed
+        id: check
+        run: |
+          git fetch origin main
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "needed=false" >> $GITHUB_OUTPUT
+            echo "✅  develop already contains every commit on main — nothing to sync."
+          else
+            echo "needed=true" >> $GITHUB_OUTPUT
+            echo "ℹ️  main has commits develop is missing — opening sync PR."
+          fi
+
+      - name: Configure git identity for the bot commit
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create sync branch and merge main into it
+        if: steps.check.outputs.needed == 'true'
+        id: merge
+        continue-on-error: true
+        run: |
+          git checkout -B chore/sync-main-to-develop
+          git merge origin/main --no-ff -m "chore: sync main → develop (automated)"
+
+      - name: Push sync branch
+        if: steps.check.outputs.needed == 'true' && steps.merge.outcome == 'success'
+        run: git push --force-with-lease origin chore/sync-main-to-develop
+
+      - name: Detect whether the sync has any file changes
+        if: steps.check.outputs.needed == 'true' && steps.merge.outcome == 'success'
+        id: diff
+        run: |
+          # Empty diff means main and develop are already content-identical and
+          # only the merge-commit graph differs. That's the safe auto-merge case.
+          # Non-empty diff means someone committed directly to main (hotfix, docs
+          # patch, emergency config) and those changes deserve human review.
+          if [ -z "$(git diff origin/develop..HEAD --name-only)" ]; then
+            echo "empty=true" >> $GITHUB_OUTPUT
+            echo "✅  Diff is empty (0 files changed) — safe to auto-merge."
+          else
+            echo "empty=false" >> $GITHUB_OUTPUT
+            echo "⚠️  Diff has file changes — will open for manual review:"
+            git diff origin/develop..HEAD --stat
+          fi
+
+      - name: Open (or update) sync PR
+        if: steps.check.outputs.needed == 'true' && steps.merge.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Body comes from the dedicated syncback template — edit that file,
+          # not this YAML, to change how the PR reads.
+          # Reviewer + assignee are only set when the diff is non-empty: an empty
+          # sync will be auto-merged in the next step, so pinging you for review
+          # on something that's about to merge itself is just noise.
+          # If a PR already exists on this branch, `gh pr create` exits non-zero.
+          # That's fine: the force-push above updated the branch and the existing
+          # PR picks up the changes automatically. We swallow the error.
+          EXTRA_FLAGS=""
+          if [ "${{ steps.diff.outputs.empty }}" = "false" ]; then
+            EXTRA_FLAGS="--reviewer Soumyadipgithub --assignee Soumyadipgithub"
+          fi
+          gh pr create \
+            --base develop \
+            --head chore/sync-main-to-develop \
+            --title "chore: sync main → develop" \
+            --body-file .github/PULL_REQUEST_TEMPLATE/syncback.md \
+            $EXTRA_FLAGS \
+          || echo "ℹ️  Sync PR already open — the force-push updated it in place."
+
+      - name: Auto-merge if the diff is empty (safe path)
+        if: steps.check.outputs.needed == 'true' && steps.merge.outcome == 'success' && steps.diff.outputs.empty == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Merge strategy is --merge (not squash/rebase) to preserve the merge
+          # commit from main. --delete-branch cleans up the temp branch so the
+          # repo doesn't accumulate stale chore/sync-* branches.
+          # If branch protection on develop blocks the bot, this step fails softly
+          # — the PR stays open for you to merge manually. We do NOT fail the
+          # workflow, because the PR is the fallback.
+          gh pr merge chore/sync-main-to-develop \
+            --merge \
+            --delete-branch \
+          && echo "✅  Auto-merged. You will receive a notification that the PR was merged." \
+          || echo "⚠️  Auto-merge blocked (likely branch protection). PR is open for manual merge."
+
+      - name: Fail loudly on merge conflict
+        if: steps.check.outputs.needed == 'true' && steps.merge.outcome == 'failure'
+        run: |
+          echo "::error title=Syncback merge conflict::main and develop have conflicting commits; the sync PR could not be opened automatically."
+          echo ""
+          echo "Resolve manually:"
+          echo "  git checkout develop && git pull"
+          echo "  git checkout -b chore/sync-main-to-develop"
+          echo "  git merge origin/main           # resolve conflicts, commit"
+          echo "  git push -u origin chore/sync-main-to-develop"
+          echo "  gh pr create --base develop --head chore/sync-main-to-develop \\"
+          echo "               --title 'chore: sync main → develop'"
+          exit 1


### PR DESCRIPTION
## What this PR does

Adds a GitHub Action that automatically closes the "1 commit ahead, 0 files changed" gap between `main` and `develop` after every release. Two new files: the workflow and a short PR template used when a syncback needs manual review.

GitHub's merge buttons always leave `main` one merge commit ahead of `develop`. Without a syncback, every future feature branch cut from `develop` inherits outdated history and release PRs get noisier. This closes that gap with zero manual work in the typical case.

**How the automation behaves:**
- **Empty diff (typical case):** bot opens PR, detects no file changes, auto-merges. You get a "PR merged" notification. Zero clicks.
- **Non-empty diff (direct-to-main hotfix):** bot opens PR with you as reviewer + assignee. You review, you merge.
- **Merge conflict:** workflow fails loudly, no PR opened. You resolve manually.

**Safety guardrails:**
- Auto-merge only runs when diff is content-empty — never merges surprise code changes into develop without review
- `GITHUB_TOKEN` only; no PAT, no secrets, no expiration, no rotation
- Only `actions/checkout@v4` + built-in `gh` CLI — no third-party actions
- Idempotent re-runs (force-push updates the existing PR, doesn't duplicate)
- Auto-merge fails softly if branch protection blocks the bot — the PR stays open, the workflow doesn't fail

**One-time repo setup required after merge:** `Settings → Actions → General → Workflow permissions` → "Read and write" + "Allow GitHub Actions to create and approve pull requests". Documented at the top of the workflow file.

## How to test

1. Merge this PR into `develop`
2. Flip the repo setting described above
3. On the next release (`develop → main`), watch the **Actions** tab — the "Auto Syncback main → develop" workflow should fire on the push to main
4. Expected: since that release's diff is content-empty, the workflow auto-merges the sync PR silently and you get a "PR merged" notification
5. Manual trigger for verification: `Actions → Auto Syncback main → develop → Run workflow` works any time

## Checklist

- [x] Branch targets \`develop\` (not \`main\`)
- [x] Branch name follows the \`<type>/issue-<n>-<description>\` convention (\`chore/auto-syncback-workflow\`)
- [x] Read [CLAUDE.md](../CLAUDE.md) before making changes
- [x] Behaviour is unchanged or the change is intentional and described above — this is CI infrastructure, no runtime code touched
- [x] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback — N/A (no Python/Rust/React code changed)
- [x] Glass design rules followed (no solid backgrounds, no Tailwind) — N/A (no UI code)
- [x] No hardcoded API keys, paths, or credentials
- [x] Tested manually with \`npm run dev\` — N/A (workflow change; validated via YAML parse + \`gh\` command dry-run)

## Screenshots (if UI changed)

N/A — CI-only change, no UI.