### PR TITLE
chore: add CODEOWNERS for auto review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS — GitHub uses this to auto-request reviews.
+#
+# Rule: the LAST matching pattern wins. Catch-all sits at the top; anything
+# more specific goes below it and overrides.
+#
+# To enforce this on a branch: Settings → Branches → branch protection rule →
+# tick "Require review from Code Owners". Combined with "Required approvals: 1",
+# this means every PR touching owned files needs an owner's approval — even
+# if another collaborator already approved.
+#
+# For now everything is owned by @Soumyadipgithub. As the team grows, add
+# area-specific rules below, e.g.:
+#   /python/      @backend-person
+#   /website/     @frontend-person
+#   /.github/     @Soumyadipgithub   # keep infra owned by the admin
+
+*   @Soumyadipgithub


### PR DESCRIPTION
## What this PR does

Adds `.github/CODEOWNERS` with a catch-all entry `* @Soumyadipgithub` so every PR automatically requests review from the repo owner. Commented examples included for splitting ownership by area (python/, website/, .github/) as the team grows. No runtime or behaviour change — PR-review metadata only.

## How to test

1. Merge this PR.
2. On the next feature PR, confirm the "Reviewers" sidebar auto-suggests `@Soumyadipgithub`.
3. Optional next step (not in this PR): flip "Require review from Code Owners" on `main` branch protection to make CODEOWNERS enforcement mandatory, not advisory.

## Checklist

- [x] Branch targets `develop` (not `main`)
- [x] Branch name follows the `<type>/<description>` convention (`chore/add-codeowners`)
- [x] Read [CLAUDE.md](../CLAUDE.md) before making changes
- [x] Behaviour is unchanged (CI / runtime logic not touched)
- [x] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback (N/A — no Python/runtime change)
- [x] Glass design rules followed (N/A — no UI change)
- [x] No hardcoded API keys, paths, or credentials
- [x] Tested manually with `npm run dev` (N/A — no code change)

## Screenshots (if UI changed)

N/A — no UI change.