### PR TITLE
chore: propagate CODEOWNERS to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS — GitHub uses this to auto-request reviews.
+#
+# Rule: the LAST matching pattern wins. Catch-all sits at the top; anything
+# more specific goes below it and overrides.
+#
+# To enforce this on a branch: Settings → Branches → branch protection rule →
+# tick "Require review from Code Owners". Combined with "Required approvals: 1",
+# this means every PR touching owned files needs an owner's approval — even
+# if another collaborator already approved.
+#
+# For now everything is owned by @Soumyadipgithub. As the team grows, add
+# area-specific rules below, e.g.:
+#   /python/      @backend-person
+#   /website/     @frontend-person
+#   /.github/     @Soumyadipgithub   # keep infra owned by the admin
+
+*   @Soumyadipgithub


### PR DESCRIPTION
## What this PR does

Propagates `.github/CODEOWNERS` from `develop` to `main` so PRs targeting either branch auto-request review from the owner. No product code changes, no version bump.

## Why this is not a release

This PR follows the `chore:` convention rather than `release.md` because:

- Only a single 17-line infrastructure file changes
- Zero runtime / UI / website / API surface affected
- No new user-facing behaviour to announce
- A version bump to v3.0.1 would be noise — nothing shipped to end users

CODEOWNERS needs to live on `main` as well as `develop` so that any PR targeting `main` (release PRs, hotfixes) also auto-requests review.

## Files changed

\`\`\`
 .github/CODEOWNERS | 17 +++++++++++++++++
 1 file changed, 17 insertions(+)
\`\`\`

## Pre-merge checks

- [x] No code / behaviour change (verified by diff above)
- [x] No version bump required (not a product release)
- [x] CODEOWNERS already verified on develop (PR #11, merged)
- [ ] CI passes (Python Syntax, Frontend Build, Rust Check) — will auto-run
- [ ] Approval — you as admin, or "Merge without waiting for requirements (bypass rules)"

## Post-merge

Auto-syncback workflow will fire on push to `main`, detect an empty diff (main and develop are now identical), and auto-merge the sync PR with no file changes — a "0 files changed" notification only.