### PR TITLE
release: v3.0.0 — automated release pipeline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/syncback.md
+++ b/.github/PULL_REQUEST_TEMPLATE/syncback.md
@@ -3,9 +3,13 @@
 
 ## Syncback: `main` → `develop`
 
-Realigns `develop` with `main`. If you're reading this in an open PR, it means **main has file changes develop doesn't** (hotfix, docs patch, or something committed directly to main). Empty-diff syncs auto-merge and you'd just see a "PR merged" notification instead.
+Realigns `develop` with `main`.
 
-- [ ] Diff looks correct for the direct-to-main change
+**If the diff is empty (0 files changed):** it's a merge-graph-only sync from a release PR. Safe to merge in one click — tick **Merge without waiting for requirements (bypass rules)** and hit merge. CI checks will sit as "Expected" forever because GitHub's anti-loop rule blocks workflows on bot-created PRs; that's expected, not a problem.
+
+**If the diff has file changes:** main has content develop doesn't (hotfix, docs patch, emergency config). Review it before merging.
+
+- [ ] Diff looks correct for the direct-to-main change (if any)
 - [ ] No merge conflicts
 
-Click **Merge pull request** — done.
+Empty-diff → one-click bypass-merge. Non-empty → review, then merge.

--- a/.github/workflows/auto-syncback.yml
+++ b/.github/workflows/auto-syncback.yml
@@ -17,9 +17,18 @@ name: Auto Syncback main → develop
 # ──────────────────────────────────────────────────────────────────────────────
 #
 # NOTE ON CI: PRs opened by GITHUB_TOKEN do not trigger other workflows
-# (GitHub's built-in anti-loop protection). If you want CI to run on the sync
-# PR, close + reopen it once — that re-triggers checks under your user account.
-# For a typical "0 files changed" sync PR, CI isn't strictly needed anyway.
+# (GitHub's built-in anti-loop protection). The required status checks on
+# develop will sit in "Expected — waiting for status to be reported" forever
+# on a sync PR. That's fine: you, as admin, merge via the
+# "Merge without waiting for requirements (bypass rules)" checkbox.
+#
+# NOTE ON "AUTO-MERGE": This workflow attempts auto-merge on empty-diff syncs,
+# but on a personal repo with strict branch protection it WILL be blocked —
+# the bot can't self-approve and can't satisfy required checks that never run.
+# You will still need one manual click per sync PR. The auto-merge step is
+# kept for the two future-scenarios where it works: (a) repo is moved to an
+# org with a ruleset that bypasses the bot, or (b) someone swaps GITHUB_TOKEN
+# for a PAT / fine-grained token. Today, expect to merge manually.
 
 on:
   push:
@@ -78,12 +87,14 @@ jobs:
         id: diff
         run: |
           # Empty diff means main and develop are already content-identical and
-          # only the merge-commit graph differs. That's the safe auto-merge case.
+          # only the merge-commit graph differs — the "bypass rules and merge"
+          # case. No human review needed beyond one click.
           # Non-empty diff means someone committed directly to main (hotfix, docs
-          # patch, emergency config) and those changes deserve human review.
+          # patch, emergency config) and those changes deserve human review
+          # before being merged back.
           if [ -z "$(git diff origin/develop..HEAD --name-only)" ]; then
             echo "empty=true" >> $GITHUB_OUTPUT
-            echo "✅  Diff is empty (0 files changed) — safe to auto-merge."
+            echo "✅  Diff is empty (0 files changed) — safe to merge (one-click bypass)."
           else
             echo "empty=false" >> $GITHUB_OUTPUT
             echo "⚠️  Diff has file changes — will open for manual review:"
@@ -98,8 +109,8 @@ jobs:
           # Body comes from the dedicated syncback template — edit that file,
           # not this YAML, to change how the PR reads.
           # Reviewer + assignee are only set when the diff is non-empty: an empty
-          # sync will be auto-merged in the next step, so pinging you for review
-          # on something that's about to merge itself is just noise.
+          # sync is a one-click bypass-merge for the admin, so pinging yourself
+          # for review on something you'll just click-merge is noise.
           # If a PR already exists on this branch, `gh pr create` exits non-zero.
           # That's fine: the force-push above updated the branch and the existing
           # PR picks up the changes automatically. We swallow the error.
@@ -115,22 +126,29 @@ jobs:
             $EXTRA_FLAGS \
           || echo "ℹ️  Sync PR already open — the force-push updated it in place."
 
-      - name: Auto-merge if the diff is empty (safe path)
+      - name: Try auto-merge on empty diff (usually blocked — that's OK)
         if: steps.check.outputs.needed == 'true' && steps.merge.outcome == 'success' && steps.diff.outputs.empty == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # On a personal repo with strict develop protection, the bot is
+          # blocked here — it can't self-approve and can't pass required checks
+          # that never run (anti-loop rule). The admin merges manually via the
+          # "Merge without waiting for requirements (bypass rules)" checkbox.
+          #
+          # This step is retained so the flow works automatically if you later:
+          #   (a) move the repo into a GitHub organization and add a ruleset
+          #       with `github-actions` as a bypass actor, or
+          #   (b) swap GITHUB_TOKEN for a PAT with admin merge rights.
+          #
           # Merge strategy is --merge (not squash/rebase) to preserve the merge
           # commit from main. --delete-branch cleans up the temp branch so the
           # repo doesn't accumulate stale chore/sync-* branches.
-          # If branch protection on develop blocks the bot, this step fails softly
-          # — the PR stays open for you to merge manually. We do NOT fail the
-          # workflow, because the PR is the fallback.
           gh pr merge chore/sync-main-to-develop \
             --merge \
             --delete-branch \
-          && echo "✅  Auto-merged. You will receive a notification that the PR was merged." \
-          || echo "⚠️  Auto-merge blocked (likely branch protection). PR is open for manual merge."
+          && echo "✅  Auto-merged (org ruleset or PAT path active)." \
+          || echo "ℹ️  Auto-merge blocked by branch protection — expected on a personal repo. Merge manually with the 'bypass rules' checkbox."
 
       - name: Fail loudly on merge conflict
         if: steps.check.outputs.needed == 'true' && steps.merge.outcome == 'failure'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 # Runs on every push to main.
-# Reads the version from src-tauri/tauri.conf.json, compares it to the
-# latest published GitHub release, and only proceeds if the version is higher.
-# The dev's only job: bump the version number → merge to main → done.
+# Reads the version from src-tauri/tauri.conf.json (single source of truth),
+# compares it to the latest published GitHub release, and only proceeds if
+# the version is strictly higher. The dev's only job: bump the version → merge.
 
 on:
   push:
@@ -12,9 +12,14 @@ on:
 permissions:
   contents: write   # create tags + GitHub Release
 
+# Prevent two release jobs racing if commits land in quick succession.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
 
-  # ── Step 1: Check whether the version was bumped ────────────────────────────
+  # ── Step 1: Detect whether a new release is needed ──────────────────────────
   version-check:
     name: Version Check
     runs-on: ubuntu-latest
@@ -29,41 +34,50 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Read version from the single source of truth
           APP_VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
           echo "App version: $APP_VERSION"
 
-          # Get latest published release tag (returns empty string if none exist)
           LATEST_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null || echo "")
-          LATEST_VERSION=${LATEST_TAG#v}   # strip leading "v"
+          LATEST_VERSION=${LATEST_TAG#v}
           echo "Latest release: ${LATEST_TAG:-none}"
 
-          # Compare using sort -V (version-aware sort)
           if [ -z "$LATEST_VERSION" ]; then
             # No releases yet — always release
             echo "should_release=true" >> "$GITHUB_OUTPUT"
-          elif printf '%s\n%s\n' "$LATEST_VERSION" "$APP_VERSION" \
-               | sort -V -C 2>/dev/null; then
-            # LATEST_VERSION >= APP_VERSION → already released, skip
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
           else
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            # Release only when APP_VERSION is strictly greater than LATEST_VERSION.
+            # Find the higher of the two; if APP is higher AND different → new release.
+            HIGHEST=$(printf '%s\n%s\n' "$LATEST_VERSION" "$APP_VERSION" | sort -V | tail -1)
+            if [ "$APP_VERSION" != "$LATEST_VERSION" ] && [ "$HIGHEST" = "$APP_VERSION" ]; then
+              echo "should_release=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
           echo "version=$APP_VERSION" >> "$GITHUB_OUTPUT"
 
   # ── Step 2: Matrix build — only runs when version was bumped ────────────────
+  # NOTE: fail-fast is false so all platforms attempt to upload assets.
+  # If one platform fails after another has already created the release tag,
+  # re-run only the failed job from the GitHub Actions UI to add its assets.
   build:
-    name: Build (${{ matrix.platform }})
+    name: Build (${{ matrix.sidecar-target }})
     needs: version-check
     if: needs.version-check.outputs.should_release == 'true'
     strategy:
       fail-fast: false
       matrix:
         include:
+          # Windows — MSVC toolchain (default on windows-latest)
           - platform: windows-latest
             sidecar-target: x86_64-pc-windows-msvc
-          - platform: macos-latest
+          # macOS Intel — use macos-13 for a native x86_64 runner
+          - platform: macos-13
             sidecar-target: x86_64-apple-darwin
+          # macOS Apple Silicon — macos-latest is now M1/M2 (macos-14)
+          - platform: macos-latest
+            sidecar-target: aarch64-apple-darwin
+          # Linux x86_64
           - platform: ubuntu-22.04
             sidecar-target: x86_64-unknown-linux-gnu
 
@@ -117,13 +131,33 @@ jobs:
             portaudio19-dev
 
       # ── Build Python sidecar ────────────────────────────────────────────────
+      # Windows: invoke PyInstaller via CLI flags (not the repo .spec file) so
+      # the output binary is named with the correct -msvc triple that Tauri
+      # expects. The repo's .spec file uses -gnu (for local dev) and is not
+      # used here to avoid the confusing rename step.
       - name: Build sidecar (Windows)
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          pyinstaller syncspeaker-sidecar-x86_64-pc-windows-gnu.spec --distpath dist-py
+          pyinstaller `
+            --onefile `
+            --name "syncspeaker-sidecar-${{ matrix.sidecar-target }}" `
+            --hidden-import groq `
+            --hidden-import groq._client `
+            --hidden-import groq.resources `
+            --hidden-import httpx `
+            --hidden-import anyio `
+            --exclude-module matplotlib `
+            --exclude-module PIL `
+            --exclude-module Pillow `
+            --exclude-module tkinter `
+            --exclude-module pandas `
+            --exclude-module IPython `
+            --exclude-module scipy `
+            --distpath dist-py `
+            python\sidecar_main.py
           New-Item -ItemType Directory -Force src-tauri/binaries | Out-Null
-          Copy-Item "dist-py/syncspeaker-sidecar-x86_64-pc-windows-gnu.exe" `
+          Copy-Item "dist-py/syncspeaker-sidecar-${{ matrix.sidecar-target }}.exe" `
             "src-tauri/binaries/syncspeaker-sidecar-${{ matrix.sidecar-target }}.exe"
 
       - name: Build sidecar (macOS / Linux)
@@ -155,3 +189,4 @@ jobs:
             See [CHANGELOG.md](https://github.com/Soumyadipgithub/SyncSpeak/blob/main/CHANGELOG.md) for what's new.
           releaseDraft: false
           prerelease: false
+          args: ${{ matrix.sidecar-target == 'aarch64-apple-darwin' && '--target aarch64-apple-darwin' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,18 @@
 name: Release
 
-# Runs on every push to main.
-# Reads the version from src-tauri/tauri.conf.json (single source of truth),
-# compares it to the latest published GitHub release, and only proceeds if
-# the version is strictly higher. The dev's only job: bump the version → merge.
-
 on:
   push:
     branches: [main]
 
 permissions:
-  contents: write   # create tags + GitHub Release
+  contents: write
 
-# Prevent two release jobs racing if commits land in quick succession.
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
 
-  # ── Step 1: Detect whether a new release is needed ──────────────────────────
   version-check:
     name: Version Check
     runs-on: ubuntu-latest
@@ -42,11 +35,8 @@ jobs:
           echo "Latest release: ${LATEST_TAG:-none}"
 
           if [ -z "$LATEST_VERSION" ]; then
-            # No releases yet — always release
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           else
-            # Release only when APP_VERSION is strictly greater than LATEST_VERSION.
-            # Find the higher of the two; if APP is higher AND different → new release.
             HIGHEST=$(printf '%s\n%s\n' "$LATEST_VERSION" "$APP_VERSION" | sort -V | tail -1)
             if [ "$APP_VERSION" != "$LATEST_VERSION" ] && [ "$HIGHEST" = "$APP_VERSION" ]; then
               echo "should_release=true" >> "$GITHUB_OUTPUT"
@@ -56,10 +46,8 @@ jobs:
           fi
           echo "version=$APP_VERSION" >> "$GITHUB_OUTPUT"
 
-  # ── Step 2: Matrix build — only runs when version was bumped ────────────────
-  # NOTE: fail-fast is false so all platforms attempt to upload assets.
-  # If one platform fails after another has already created the release tag,
-  # re-run only the failed job from the GitHub Actions UI to add its assets.
+  # Build on all platforms, upload bundles as artifacts.
+  # publish job runs only after ALL legs succeed — no partial releases.
   build:
     name: Build (${{ matrix.sidecar-target }})
     needs: version-check
@@ -68,25 +56,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Windows — MSVC toolchain (default on windows-latest)
           - platform: windows-latest
             sidecar-target: x86_64-pc-windows-msvc
-          # macOS Intel — use macos-13 for a native x86_64 runner
-          - platform: macos-13
+            tauri-args: ''
+          - platform: macos-13          # Intel runner — native x86_64
             sidecar-target: x86_64-apple-darwin
-          # macOS Apple Silicon — macos-latest is now M1/M2 (macos-14)
-          - platform: macos-latest
+            tauri-args: '--target x86_64-apple-darwin'
+          - platform: macos-latest      # M1/M2 runner — native aarch64
             sidecar-target: aarch64-apple-darwin
-          # Linux x86_64
+            tauri-args: '--target aarch64-apple-darwin'
           - platform: ubuntu-22.04
             sidecar-target: x86_64-unknown-linux-gnu
+            tauri-args: ''
 
     runs-on: ${{ matrix.platform }}
 
     steps:
       - uses: actions/checkout@v4
 
-      # ── Node ────────────────────────────────────────────────────────────────
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -94,14 +81,12 @@ jobs:
 
       - run: npm ci
 
-      # ── Rust ────────────────────────────────────────────────────────────────
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      # ── Python ──────────────────────────────────────────────────────────────
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -117,7 +102,6 @@ jobs:
             pip install webrtcvad
           fi
 
-      # ── Linux system deps ───────────────────────────────────────────────────
       - name: Install Linux system dependencies
         if: matrix.platform == 'ubuntu-22.04'
         run: |
@@ -130,11 +114,8 @@ jobs:
             build-essential \
             portaudio19-dev
 
-      # ── Build Python sidecar ────────────────────────────────────────────────
-      # Windows: invoke PyInstaller via CLI flags (not the repo .spec file) so
-      # the output binary is named with the correct -msvc triple that Tauri
-      # expects. The repo's .spec file uses -gnu (for local dev) and is not
-      # used here to avoid the confusing rename step.
+      # Windows: uses inline CLI flags (matching the updated .spec file) so the
+      # output binary carries the correct -msvc triple that Tauri expects.
       - name: Build sidecar (Windows)
         if: matrix.platform == 'windows-latest'
         shell: pwsh
@@ -178,15 +159,45 @@ jobs:
              "src-tauri/binaries/syncspeaker-sidecar-${{ matrix.sidecar-target }}"
           chmod +x "src-tauri/binaries/syncspeaker-sidecar-${{ matrix.sidecar-target }}"
 
-      # ── Build Tauri + publish release ───────────────────────────────────────
+      # Build Tauri bundles but do NOT publish here — publish job does that
+      # atomically once ALL matrix legs succeed.
       - uses: tauri-apps/tauri-action@v0
+        with:
+          args: ${{ matrix.tauri-args }}
+
+      - name: Upload bundle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundles-${{ matrix.sidecar-target }}
+          if-no-files-found: error
+          path: |
+            src-tauri/target/**/bundle/**/*.exe
+            src-tauri/target/**/bundle/**/*.msi
+            src-tauri/target/**/bundle/**/*.dmg
+            src-tauri/target/**/bundle/**/*.AppImage
+            src-tauri/target/**/bundle/**/*.deb
+
+  # Runs only after every matrix leg succeeds — guarantees atomic publish.
+  publish:
+    name: Publish Release
+    needs: [version-check, build]
+    if: needs.version-check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all bundle artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bundles-*
+          merge-multiple: true
+          path: release-assets
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.version-check.outputs.version }}
+          name: SyncSpeak v${{ needs.version-check.outputs.version }}
+          body: |
+            See [CHANGELOG.md](https://github.com/Soumyadipgithub/SyncSpeak/blob/main/CHANGELOG.md) for what's new.
+          files: release-assets/**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tagName: v${{ needs.version-check.outputs.version }}
-          releaseName: 'SyncSpeak v${{ needs.version-check.outputs.version }}'
-          releaseBody: |
-            See [CHANGELOG.md](https://github.com/Soumyadipgithub/SyncSpeak/blob/main/CHANGELOG.md) for what's new.
-          releaseDraft: false
-          prerelease: false
-          args: ${{ matrix.sidecar-target == 'aarch64-apple-darwin' && '--target aarch64-apple-darwin' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,157 @@
+name: Release
+
+# Runs on every push to main.
+# Reads the version from src-tauri/tauri.conf.json, compares it to the
+# latest published GitHub release, and only proceeds if the version is higher.
+# The dev's only job: bump the version number → merge to main → done.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write   # create tags + GitHub Release
+
+jobs:
+
+  # ── Step 1: Check whether the version was bumped ────────────────────────────
+  version-check:
+    name: Version Check
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare tauri.conf.json version with latest release
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Read version from the single source of truth
+          APP_VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
+          echo "App version: $APP_VERSION"
+
+          # Get latest published release tag (returns empty string if none exist)
+          LATEST_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null || echo "")
+          LATEST_VERSION=${LATEST_TAG#v}   # strip leading "v"
+          echo "Latest release: ${LATEST_TAG:-none}"
+
+          # Compare using sort -V (version-aware sort)
+          if [ -z "$LATEST_VERSION" ]; then
+            # No releases yet — always release
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n%s\n' "$LATEST_VERSION" "$APP_VERSION" \
+               | sort -V -C 2>/dev/null; then
+            # LATEST_VERSION >= APP_VERSION → already released, skip
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+
+  # ── Step 2: Matrix build — only runs when version was bumped ────────────────
+  build:
+    name: Build (${{ matrix.platform }})
+    needs: version-check
+    if: needs.version-check.outputs.should_release == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows-latest
+            sidecar-target: x86_64-pc-windows-msvc
+          - platform: macos-latest
+            sidecar-target: x86_64-apple-darwin
+          - platform: ubuntu-22.04
+            sidecar-target: x86_64-unknown-linux-gnu
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Node ────────────────────────────────────────────────────────────────
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      # ── Rust ────────────────────────────────────────────────────────────────
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # ── Python ──────────────────────────────────────────────────────────────
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          pip install pyinstaller
+          pip install -r requirements.txt
+          if [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            pip install webrtcvad-wheels
+          else
+            pip install webrtcvad
+          fi
+
+      # ── Linux system deps ───────────────────────────────────────────────────
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            build-essential \
+            portaudio19-dev
+
+      # ── Build Python sidecar ────────────────────────────────────────────────
+      - name: Build sidecar (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          pyinstaller syncspeaker-sidecar-x86_64-pc-windows-gnu.spec --distpath dist-py
+          New-Item -ItemType Directory -Force src-tauri/binaries | Out-Null
+          Copy-Item "dist-py/syncspeaker-sidecar-x86_64-pc-windows-gnu.exe" `
+            "src-tauri/binaries/syncspeaker-sidecar-${{ matrix.sidecar-target }}.exe"
+
+      - name: Build sidecar (macOS / Linux)
+        if: matrix.platform != 'windows-latest'
+        run: |
+          pyinstaller \
+            --onefile \
+            --name "syncspeaker-sidecar-${{ matrix.sidecar-target }}" \
+            --hidden-import groq \
+            --hidden-import groq._client \
+            --hidden-import groq.resources \
+            --hidden-import httpx \
+            --hidden-import anyio \
+            --distpath dist-py \
+            python/sidecar_main.py
+          mkdir -p src-tauri/binaries
+          cp "dist-py/syncspeaker-sidecar-${{ matrix.sidecar-target }}" \
+             "src-tauri/binaries/syncspeaker-sidecar-${{ matrix.sidecar-target }}"
+          chmod +x "src-tauri/binaries/syncspeaker-sidecar-${{ matrix.sidecar-target }}"
+
+      # ── Build Tauri + publish release ───────────────────────────────────────
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: v${{ needs.version-check.outputs.version }}
+          releaseName: 'SyncSpeak v${{ needs.version-check.outputs.version }}'
+          releaseBody: |
+            See [CHANGELOG.md](https://github.com/Soumyadipgithub/SyncSpeak/blob/main/CHANGELOG.md) for what's new.
+          releaseDraft: false
+          prerelease: false


### PR DESCRIPTION
## Release: v3.0.0

<!-- e.g. v3.0.0 — Public Launch, or v3.1.0 — Tamil support -->

## What's in this release

### CI / infra
- **[NEW]** \.github/workflows/release.yml\ — fully automated release pipeline (closes #15)
  - Reads version from \src-tauri/tauri.conf.json\ on every push to \main\
  - Builds PyInstaller sidecar + Tauri bundles for Windows (x86_64), macOS Intel, macOS Apple Silicon, and Linux
  - Publishes GitHub Release atomically only after ALL platform builds succeed

### Desktop app
- No changes

### Website
- No changes

### Fixes
- No runtime fixes

## Version bump

- [x] \package.json\ — v3.0.0 (unchanged, already correct)
- [x] \src-tauri/tauri.conf.json\ — v3.0.0 (unchanged, already correct)
- [x] \CHANGELOG.md\ — v3.0.0 entry exists

## Pre-release checks

- [x] No personal data / credentials / TODOs leaked in the diff
- [x] No file over 5 MB in the diff
- [x] All required CI jobs pass
- [x] Only one new file added (\.github/workflows/release.yml\)

## Rollout plan

1. Merge this PR → \main\ updates
2. Release workflow fires automatically — detects v3.0.0 > no existing releases
3. Builds Windows \.exe\/\.msi\, macOS Intel \.dmg\, macOS ARM \.dmg\, Linux \.AppImage\/\.deb\
4. Publishes GitHub Release v3.0.0 atomically
5. Website download button starts working on next Cloudflare deploy
6. Open the sync-back PR: \main → develop\

## Rollback plan

- **Website**: Cloudflare → Workers → Deployments → promote previous version (≤1 min)
- **Desktop app**: previous release binaries remain on GitHub Releases