### PR TITLE
fix: tauri npm script and webrtcvad pyinstaller hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,15 +114,22 @@ jobs:
             build-essential \
             portaudio19-dev
 
-      # Windows: uses inline CLI flags (matching the updated .spec file) so the
-      # output binary carries the correct -msvc triple that Tauri expects.
+      # Windows: invoke PyInstaller via CLI flags so the output binary carries
+      # the correct -msvc triple. A no-op hook overrides the broken webrtcvad
+      # hook in pyinstaller-hooks-contrib; --collect-binaries picks up the .pyd.
       - name: Build sidecar (Windows)
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
+          # Override broken webrtcvad hook with a no-op so PyInstaller doesn't crash
+          New-Item -ItemType Directory -Force pyi-hooks | Out-Null
+          "" | Out-File pyi-hooks/hook-webrtcvad.py -Encoding utf8
+
           pyinstaller `
             --onefile `
             --name "syncspeaker-sidecar-${{ matrix.sidecar-target }}" `
+            --additional-hooks-dir pyi-hooks `
+            --collect-binaries webrtcvad `
             --hidden-import groq `
             --hidden-import groq._client `
             --hidden-import groq.resources `

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "tauri dev",
     "build": "vite build && tauri build",
+    "tauri": "tauri",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes the CI failures seen on PR #17.

Fix 1 - All platforms (npm error Missing script tauri): Added "tauri": "tauri" to package.json scripts so tauri-action can call npm run tauri build using the locally installed @tauri-apps/cli.

Fix 2 - Windows (PyInstaller webrtcvad hook crash): The pyinstaller-hooks-contrib hook for webrtcvad-wheels fails to import on the CI runner. Fixed by creating a no-op override hook via --additional-hooks-dir and explicitly collecting the binary with --collect-binaries webrtcvad.
