### PR TITLE
release: v3.0.0 — automated release pipeline (CI fixes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,15 +114,22 @@ jobs:
             build-essential \
             portaudio19-dev
 
-      # Windows: uses inline CLI flags (matching the updated .spec file) so the
-      # output binary carries the correct -msvc triple that Tauri expects.
+      # Windows: invoke PyInstaller via CLI flags so the output binary carries
+      # the correct -msvc triple. A no-op hook overrides the broken webrtcvad
+      # hook in pyinstaller-hooks-contrib; --collect-binaries picks up the .pyd.
       - name: Build sidecar (Windows)
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
+          # Override broken webrtcvad hook with a no-op so PyInstaller doesn't crash
+          New-Item -ItemType Directory -Force pyi-hooks | Out-Null
+          "" | Out-File pyi-hooks/hook-webrtcvad.py -Encoding utf8
+
           pyinstaller `
             --onefile `
             --name "syncspeaker-sidecar-${{ matrix.sidecar-target }}" `
+            --additional-hooks-dir pyi-hooks `
+            --collect-binaries webrtcvad `
             --hidden-import groq `
             --hidden-import groq._client `
             --hidden-import groq.resources `

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "tauri dev",
     "build": "vite build && tauri build",
+    "tauri": "tauri",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Release: v3.0.0 — automated release pipeline (CI fixes)

## What's in this release

### CI / infra
- **[NEW]** `.github/workflows/release.yml` — fully automated release pipeline (closes #15)
  - Auto-detects version bump in `src-tauri/tauri.conf.json` on every push to `main`
  - Matrix builds PyInstaller sidecar + Tauri bundles for Windows x86_64, macOS Intel, macOS Apple Silicon, Linux x86_64
  - Publishes GitHub Release atomically — all platforms must succeed before any asset is uploaded
- **FIX** `release.yml` — corrected inverted version-check logic (`sort -V` was backwards)
- **FIX** `release.yml` — atomic publish via `build` + separate `publish` job (no partial releases)
- **FIX** `release.yml` — added Apple Silicon matrix entry (`aarch64-apple-darwin` on `macos-latest`)
- **FIX** `release.yml` — added concurrency guard to prevent race conditions on rapid pushes
- **FIX** `release.yml` — symmetric `tauri-args` across both macOS legs
- **FIX** `release.yml` — Windows sidecar now uses correct `-msvc` triple (no confusing rename step)
- **FIX** `release.yml` — no-op webrtcvad hook + `--collect-binaries` to fix PyInstaller crash on Windows CI
- **FIX** `package.json` — added `"tauri": "tauri"` script so `tauri-action` resolves `npm run tauri`

### Desktop app
- No changes

### Website
- No changes

### Fixes
- No runtime fixes

## Version bump

- [x] `package.json` — v3.0.0 (unchanged, already correct)
- [x] `src-tauri/tauri.conf.json` — v3.0.0 (unchanged, already correct)
- [x] `CHANGELOG.md` — v3.0.0 entry exists

## Pre-release checks

- [x] No personal data / credentials / TODOs leaked in the diff
- [x] No file over 5 MB in the diff
- [x] All required CI jobs pass
- [x] Only workflow and package.json touched — no app behaviour changed

## Rollout plan

1. Merge this PR → `main` updates
2. Release workflow fires automatically — detects v3.0.0 > no existing releases
3. Builds Windows `.exe`/`.msi`, macOS Intel `.dmg`, macOS ARM `.dmg`, Linux `.AppImage`/`.deb`
4. Publishes GitHub Release v3.0.0 atomically
5. Website download button starts working on next Cloudflare deploy
6. Open the sync-back PR: `main → develop`

## Rollback plan

- **Website**: Cloudflare → Workers → Deployments → promote previous version (≤1 min)
- **Desktop app**: previous release binaries remain on GitHub Releases
