### PR TITLE
fix: use macos-latest for Intel cross-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,10 @@ jobs:
           - platform: windows-latest
             sidecar-target: x86_64-pc-windows-msvc
             tauri-args: ''
-          - platform: macos-13          # Intel runner — native x86_64
+          - platform: macos-latest      # cross-compile x86_64 on ARM runner
             sidecar-target: x86_64-apple-darwin
             tauri-args: '--target x86_64-apple-darwin'
-          - platform: macos-latest      # M1/M2 runner — native aarch64
+          - platform: macos-latest      # native aarch64 on ARM runner
             sidecar-target: aarch64-apple-darwin
             tauri-args: '--target aarch64-apple-darwin'
           - platform: ubuntu-22.04
@@ -82,6 +82,8 @@ jobs:
       - run: npm ci
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.sidecar-target == 'x86_64-apple-darwin' && 'x86_64-apple-darwin' || '' }}
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
macOS Intel build (macos-13) was stuck queued for 33 min — scarce runner pool. Changed to macos-latest (ARM runner) with cross-compilation via --target x86_64-apple-darwin. Added Rust x86_64-apple-darwin target for cross-compile support.