### PR TITLE
release: v3.0.0 — macOS runner fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,10 @@ jobs:
           - platform: windows-latest
             sidecar-target: x86_64-pc-windows-msvc
             tauri-args: ''
-          - platform: macos-13          # Intel runner — native x86_64
+          - platform: macos-latest      # cross-compile x86_64 on ARM runner
             sidecar-target: x86_64-apple-darwin
             tauri-args: '--target x86_64-apple-darwin'
-          - platform: macos-latest      # M1/M2 runner — native aarch64
+          - platform: macos-latest      # native aarch64 on ARM runner
             sidecar-target: aarch64-apple-darwin
             tauri-args: '--target aarch64-apple-darwin'
           - platform: ubuntu-22.04
@@ -82,6 +82,8 @@ jobs:
       - run: npm ci
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.sidecar-target == 'x86_64-apple-darwin' && 'x86_64-apple-darwin' || '' }}
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Fixes the stuck macOS Intel build that blocked the first release. Changed macos-13 (scarce runner pool) to macos-latest with cross-compilation. All other changes were already merged to main in PR #20.