### PR TITLE
revert: direct commit to develop

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,14 +38,7 @@
     ],
     "externalBin": [
       "binaries/syncspeaker-sidecar"
-    ],
-    "windows": {
-      "nsis": {
-        "installerIcon": "icons/icon.ico",
-        "uninstallerIcon": "icons/icon.ico",
-        "displayLanguageSelector": true
-      }
-    }
+    ]
   },
   "plugins": {
     "shell": {}


### PR DESCRIPTION
Reverting the accidental direct commit edc2f60 to follow project rules (branch-first workflow). I will recreate this feature through a proper PR after this is merged.