### PR TITLE
feat: set custom NSIS installer icon

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,14 @@
     ],
     "externalBin": [
       "binaries/syncspeaker-sidecar"
-    ]
+    ],
+    "windows": {
+      "nsis": {
+        "installerIcon": "icons/icon.ico",
+        "uninstallerIcon": "icons/icon.ico",
+        "displayLanguageSelector": true
+      }
+    }
   },
   "plugins": {
     "shell": {}


### PR DESCRIPTION
## What this PR does

This PR explicitly sets the Windows NSIS installer and uninstaller icons to use the SyncSpeak application logo (`icons/icon.ico`) instead of the default generic NSIS icon.

This ensures that the downloaded setup file reflects the application branding from the very first interaction.

## How to test

1. Review `src-tauri/tauri.conf.json`.
2. Verify that `bundle.windows.nsis.installerIcon` and `uninstallerIcon` point to `icons/icon.ico`.
3. (Optional) Run a Windows build with `npm run tauri build` to verify the generated installer icon.

## Checklist

- [x] Branch targets `develop` (not `main`)
- [x] Branch name follows the `<type>/issue-<n>-<description>` convention
- [x] Read [CLAUDE.md](../CLAUDE.md) before making changes
- [x] Behaviour is unchanged or the change is intentional and described above
- [x] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback
- [x] Glass design rules followed (no solid backgrounds, no Tailwind)
- [x] No hardcoded API keys, paths, or credentials
- [x] Tested manually with `npm run build` (website build check)

## Screenshots (if UI changed)

N/A (Installer branding change)
