### PR TITLE
release: v3.0.0 — Final Branding & Sync

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,6 @@
     "windows": {
       "nsis": {
         "installerIcon": "icons/icon.ico",
-        "uninstallerIcon": "icons/icon.ico",
         "displayLanguageSelector": true
       }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,14 @@
     ],
     "externalBin": [
       "binaries/syncspeaker-sidecar"
-    ]
+    ],
+    "windows": {
+      "nsis": {
+        "installerIcon": "icons/icon.ico",
+        "uninstallerIcon": "icons/icon.ico",
+        "displayLanguageSelector": true
+      }
+    }
   },
   "plugins": {
     "shell": {}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,14 +38,7 @@
     ],
     "externalBin": [
       "binaries/syncspeaker-sidecar"
-    ],
-    "windows": {
-      "nsis": {
-        "installerIcon": "icons/icon.ico",
-        "uninstallerIcon": "icons/icon.ico",
-        "displayLanguageSelector": true
-      }
-    }
+    ]
   },
   "plugins": {
     "shell": {}


### PR DESCRIPTION
## Release: v3.0.0

v3.0.0 — Final Branding & Build Fix

## What's in this release

This release finalizes the branding and fixes a build error in the automated pipeline.

### Desktop app
- Fixed Windows NSIS installer icon to use the SyncSpeak logo.
- Removed unsupported `uninstallerIcon` field that was causing build failures.

### Website
- (Already in main) Grouped download assets by platform with human-friendly labels.

### CI / infra
- (Already in main) Automated cross-platform release pipeline with macOS cross-compilation.

## Rollout plan

1. Merge this PR → `main` updates
2. GitHub Actions builds desktop binaries and publishes to GitHub Releases (v3.0.0)
