### PR TITLE
fix: remove unsupported uninstallerIcon field

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,6 @@
     "windows": {
       "nsis": {
         "installerIcon": "icons/icon.ico",
-        "uninstallerIcon": "icons/icon.ico",
         "displayLanguageSelector": true
       }
     }


### PR DESCRIPTION
## What this PR does

This PR fixes a build error caused by an unsupported field `uninstallerIcon` in the `tauri.conf.json` NSIS configuration. 

The field was removed to align with the supported Tauri schema while keeping `installerIcon`, which is valid and ensures the setup file uses the correct branding.

## How to test

1. Verify `src-tauri/tauri.conf.json` no longer contains `uninstallerIcon`.
2. Check that CI "Rust Check" passes.

## Checklist

- [x] Branch targets `develop` (not `main`)
- [x] Branch name follows the `<type>/issue-<n>-<description>` convention
- [x] Tested with `npm run build` (website check)
