### PR TITLE
chore: unified version bump to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [3.0.1] — 2026-04-22
+
+### Changed
+- **Branding** — Custom SyncSpeak logo applied to the Windows NSIS installer.
+
 ## [3.0.0] — Public Launch (current)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncspeak",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Real-time Hindi to English voice translator for meetings",
   "main": "out/main/index.js",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncspeak"
-version = "3.0.0"
+version = "3.0.1"
 description = "Real-time Hindi to English voice translator for meetings"
 authors = ["Soumyadip Giri"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "SyncSpeak",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "identifier": "com.syncspeak.app",
   "build": {
     "beforeDevCommand": "npx vite",

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,7 +25,7 @@ const softwareJsonLd = {
   description,
   url: 'https://syncspeak.soumg.workers.dev',
   downloadUrl: 'https://github.com/Soumyadipgithub/SyncSpeak/releases/latest',
-  softwareVersion: '3.0',
+  softwareVersion: '3.0.1',
   license: 'https://opensource.org/licenses/MIT',
 };
 ---


### PR DESCRIPTION
## What this PR does

This PR synchronizes the version bump to **3.0.1** across all project files. This bump is necessary to trigger a fresh automated release on the `main` branch, ensuring that the recently fixed **Windows Installer Branding** (custom SyncSpeak logo) is included in the production binaries.

### Files updated:
- `package.json`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `website/src/pages/index.astro` (SEO metadata)
- `CHANGELOG.md`

## Checklist

- [x] Branch targets `develop`
- [x] All 5 files correctly updated to 3.0.1
- [x] Website build verified
