### PR TITLE
release: v3.0.1 — Custom Branding & Build Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [3.0.1] — 2026-04-22
+
+### Changed
+- **Branding** — Custom SyncSpeak logo applied to the Windows NSIS installer.
+
 ## [3.0.0] — Public Launch (current)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncspeak",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Real-time Hindi to English voice translator for meetings",
   "main": "out/main/index.js",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncspeak"
-version = "3.0.0"
+version = "3.0.1"
 description = "Real-time Hindi to English voice translator for meetings"
 authors = ["Soumyadip Giri"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "SyncSpeak",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "identifier": "com.syncspeak.app",
   "build": {
     "beforeDevCommand": "npx vite",

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,7 +25,7 @@ const softwareJsonLd = {
   description,
   url: 'https://syncspeak.soumg.workers.dev',
   downloadUrl: 'https://github.com/Soumyadipgithub/SyncSpeak/releases/latest',
-  softwareVersion: '3.0',
+  softwareVersion: '3.0.1',
   license: 'https://opensource.org/licenses/MIT',
 };
 ---


### PR DESCRIPTION
## Release: v3.0.1

v3.0.1 — Custom Branding & Build Fix

## What's in this release

This release applies the final branding polish and ensures the automated pipeline publishes the correct binaries.

### Desktop app
- **Installer Branding**: Fixed the Windows NSIS installer to use the SyncSpeak logo instead of the generic NSIS icon.
- **Version Bump**: Synchronized version to 3.0.1 across the app and website.

### Website
- Updated `softwareVersion` in metadata to 3.0.1.

### Fixes
- Removed invalid `uninstallerIcon` field that was blocking the CI pipeline.

## Rollout plan

1. Merge this PR → `main` updates
2. GitHub Actions builds desktop binaries for v3.0.1 (Windows/macOS/Linux)
3. Create git tag: `git tag v3.0.1 && git push --tags`
