### PR TITLE
chore: add workflow rules to CLAUDE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,31 @@
+---
+name: Chore / internal task
+about: Documentation, CI, config, dependencies, or project infrastructure
+labels: chore
+---
+
+## What needs to change
+
+<!-- Describe the task clearly. What is wrong or missing today? -->
+
+## Why it matters
+
+<!-- How does this affect contributors, agents, CI, or project health? -->
+
+## Scope
+
+<!-- Which files or areas are affected? -->
+
+- [ ] CI / GitHub Actions
+- [ ] Documentation (CLAUDE.md, CONTRIBUTING.md, docs/)
+- [ ] Config (tauri.conf.json, package.json, Cargo.toml)
+- [ ] Dependencies
+- [ ] Other: ___
+
+## Acceptance criteria
+
+<!-- How do we know this task is done? Be specific. -->
+
+1. 
+2. 
+3. 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@
 ## Checklist
 
 - [ ] Branch targets `develop` (not `main`)
-- [ ] Branch name follows the `<type>/issue-<n>-<description>` convention
+- [ ] Branch name follows the naming convention (see CONTRIBUTING.md)
 - [ ] Read [CLAUDE.md](../CLAUDE.md) before making changes
 - [ ] Behaviour is unchanged or the change is intentional and described above
 - [ ] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,54 @@ On every launch, `TranslatePage.tsx` listens for the Python `ready` event and au
 - **Transparency**: True desktop transparency active (Neutral Charcoal Spec)
 - **VB-Cable**: Physical installation required for meeting audio routing
 - **Python venv**: Must include `groq` and `webrtcvad-wheels` in addition to `requirements.txt`
+
+---
+
+## Workflow Rules
+
+Read `CONTRIBUTING.md` for the full guide. The rules below are the minimum an agent or contributor must follow.
+
+### Issue-first policy
+
+**Always create a GitHub issue before starting work.** Use the correct template:
+
+| Template | Use for |
+|----------|---------|
+| `bug_report.md` | Something broken — needs steps to reproduce |
+| `feature_request.md` | New user-facing capability |
+| `chore.md` | CI, config, docs, dependencies, infrastructure |
+
+### Branch naming
+
+```
+<type>/issue-<number>-<short-description>   ← when a GitHub issue exists
+<type>/<short-description>                  ← only if no issue exists
+```
+
+**Valid types:** `feat`, `fix`, `docs`, `refactor`, `chore`, `hotfix`
+
+**Critical rule:** Only reference an issue number if your branch directly addresses that issue. Using an unrelated issue number is **worse** than using none. If no issue exists, create one first.
+
+### PR templates — which one to use
+
+| PR direction | Template | Title format |
+|---|---|---|
+| Feature branch → `develop` | Standard (auto-loaded) | `feat: short description` |
+| `develop` → `main` | `release.md` | `release: vX.Y.Z — short theme` |
+| `main` → `develop` | `syncback.md` | `chore: sync main → develop` |
+
+### Version bump — all 5 files must match
+
+When bumping the version for a release, update **all** of these:
+
+1. `package.json` → `version`
+2. `src-tauri/tauri.conf.json` → `version`
+3. `src-tauri/Cargo.toml` → `version`
+4. `website/src/pages/index.astro` → `softwareVersion`
+5. `CHANGELOG.md` → new section at top
+
+### Never
+
+- Commit directly to `develop` or `main` — both are protected
+- Push without creating a PR first
+- Reuse an issue number from a previous, unrelated task


### PR DESCRIPTION
## What this PR does

This PR adds the missing workflow rules to `CLAUDE.md`, updates the `PULL_REQUEST_TEMPLATE.md` to remove the misleading branch naming implication, and adds a new `chore.md` issue template for infrastructure tasks. Closes #41.

## How to test

1. Review `CLAUDE.md` to confirm the new `Workflow Rules` section is present.
2. Review `.github/PULL_REQUEST_TEMPLATE.md` to confirm line 28 is updated.
3. Review `.github/ISSUE_TEMPLATE/chore.md` to confirm the new template exists.

## Checklist

- [x] Branch targets `develop` (not `main`)
- [x] Branch name follows the naming convention (see CONTRIBUTING.md)
- [x] Read [CLAUDE.md](../CLAUDE.md) before making changes
- [x] Behaviour is unchanged or the change is intentional and described above
- [x] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback
- [x] Glass design rules followed (no solid backgrounds, no Tailwind)
- [x] No hardcoded API keys, paths, or credentials
- [x] Tested manually with `npm run dev`

## Screenshots (if UI changed)

N/A
