### PR TITLE
fix: change product name to Sync Speak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [3.0.3] — 2026-04-22
+
+### Fixed
+- **Branding** — Fixed an issue where the Windows installer and taskbar displayed the application name as "SyncSpeak" instead of the official "Sync Speak" (with a space).
+
 ## [3.0.2] — 2026-04-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncspeak",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Real-time Hindi to English voice translator for meetings",
   "main": "out/main/index.js",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncspeak"
-version = "3.0.2"
+version = "3.0.3"
 description = "Real-time Hindi to English voice translator for meetings"
 authors = ["Soumyadip Giri"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "SyncSpeak",
-  "version": "3.0.2",
+  "productName": "Sync Speak",
+  "version": "3.0.3",
   "identifier": "com.syncspeak.app",
   "build": {
     "beforeDevCommand": "npx vite",

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,7 +25,7 @@ const softwareJsonLd = {
   description,
   url: 'https://syncspeak.soumg.workers.dev',
   downloadUrl: 'https://github.com/Soumyadipgithub/SyncSpeak/releases/latest',
-  softwareVersion: '3.0.2',
+  softwareVersion: '3.0.3',
   license: 'https://opensource.org/licenses/MIT',
 };
 ---


### PR DESCRIPTION
## What this PR does

This PR changes the `productName` configuration in `tauri.conf.json` from `SyncSpeak` to `Sync Speak` (with a space) to match the official branding. This ensures the Windows installer and the Start Menu display the correct name. It also bumps the version to **3.0.3** across all configuration files to trigger a fresh release. Closes #39.

## How to test

1. Check that `tauri.conf.json` has `"productName": "Sync Speak"`.
2. Check that version is `3.0.3` across the 5 relevant files.
3. Run `npm run build` inside the `website/` directory to ensure SEO metadata parses correctly.

## Checklist

- [x] Branch targets `develop` (not `main`)
- [x] Branch name follows the naming convention (see CONTRIBUTING.md)
- [x] Read [CLAUDE.md](../CLAUDE.md) before making changes
- [x] Behaviour is unchanged or the change is intentional and described above
- [x] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback
- [x] Glass design rules followed (no solid backgrounds, no Tailwind)
- [x] No hardcoded API keys, paths, or credentials
- [x] Tested manually with `npm run dev`

## Screenshots (if UI changed)

N/A
