### PR TITLE
release: v3.0.3 — Branding & Trust Updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,31 @@
+---
+name: Chore / internal task
+about: Documentation, CI, config, dependencies, or project infrastructure
+labels: chore
+---
+
+## What needs to change
+
+<!-- Describe the task clearly. What is wrong or missing today? -->
+
+## Why it matters
+
+<!-- How does this affect contributors, agents, CI, or project health? -->
+
+## Scope
+
+<!-- Which files or areas are affected? -->
+
+- [ ] CI / GitHub Actions
+- [ ] Documentation (CLAUDE.md, CONTRIBUTING.md, docs/)
+- [ ] Config (tauri.conf.json, package.json, Cargo.toml)
+- [ ] Dependencies
+- [ ] Other: ___
+
+## Acceptance criteria
+
+<!-- How do we know this task is done? Be specific. -->
+
+1. 
+2. 
+3. 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@
 ## Checklist
 
 - [ ] Branch targets `develop` (not `main`)
-- [ ] Branch name follows the `<type>/issue-<n>-<description>` convention
+- [ ] Branch name follows the naming convention (see CONTRIBUTING.md)
 - [ ] Read [CLAUDE.md](../CLAUDE.md) before making changes
 - [ ] Behaviour is unchanged or the change is intentional and described above
 - [ ] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [3.0.3] — 2026-04-22
+
+### Fixed
+- **Branding** — Fixed an issue where the Windows installer and taskbar displayed the application name as "SyncSpeak" instead of the official "Sync Speak" (with a space).
+
 ## [3.0.2] — 2026-04-22
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,54 @@ On every launch, `TranslatePage.tsx` listens for the Python `ready` event and au
 - **Transparency**: True desktop transparency active (Neutral Charcoal Spec)
 - **VB-Cable**: Physical installation required for meeting audio routing
 - **Python venv**: Must include `groq` and `webrtcvad-wheels` in addition to `requirements.txt`
+
+---
+
+## Workflow Rules
+
+Read `CONTRIBUTING.md` for the full guide. The rules below are the minimum an agent or contributor must follow.
+
+### Issue-first policy
+
+**Always create a GitHub issue before starting work.** Use the correct template:
+
+| Template | Use for |
+|----------|---------|
+| `bug_report.md` | Something broken — needs steps to reproduce |
+| `feature_request.md` | New user-facing capability |
+| `chore.md` | CI, config, docs, dependencies, infrastructure |
+
+### Branch naming
+
+```
+<type>/issue-<number>-<short-description>   ← when a GitHub issue exists
+<type>/<short-description>                  ← only if no issue exists
+```
+
+**Valid types:** `feat`, `fix`, `docs`, `refactor`, `chore`, `hotfix`
+
+**Critical rule:** Only reference an issue number if your branch directly addresses that issue. Using an unrelated issue number is **worse** than using none. If no issue exists, create one first.
+
+### PR templates — which one to use
+
+| PR direction | Template | Title format |
+|---|---|---|
+| Feature branch → `develop` | Standard (auto-loaded) | `feat: short description` |
+| `develop` → `main` | `release.md` | `release: vX.Y.Z — short theme` |
+| `main` → `develop` | `syncback.md` | `chore: sync main → develop` |
+
+### Version bump — all 5 files must match
+
+When bumping the version for a release, update **all** of these:
+
+1. `package.json` → `version`
+2. `src-tauri/tauri.conf.json` → `version`
+3. `src-tauri/Cargo.toml` → `version`
+4. `website/src/pages/index.astro` → `softwareVersion`
+5. `CHANGELOG.md` → new section at top
+
+### Never
+
+- Commit directly to `develop` or `main` — both are protected
+- Push without creating a PR first
+- Reuse an issue number from a previous, unrelated task

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncspeak",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Real-time Hindi to English voice translator for meetings",
   "main": "out/main/index.js",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncspeak"
-version = "3.0.2"
+version = "3.0.3"
 description = "Real-time Hindi to English voice translator for meetings"
 authors = ["Soumyadip Giri"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "SyncSpeak",
-  "version": "3.0.2",
+  "productName": "Sync Speak",
+  "version": "3.0.3",
   "identifier": "com.syncspeak.app",
   "build": {
     "beforeDevCommand": "npx vite",

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -131,6 +131,28 @@ const published = release ? new Date(release.published_at).toLocaleDateString() 
       }
     </section>
 
+    <section class="trusted-guide glass-card">
+      <div class="guide-content">
+        <h2>Trusted &amp; Open Source</h2>
+        <p>
+          Sync Speak is an independent open-source project. Because we don't buy expensive Microsoft certificates, Windows SmartScreen may show a <strong>"Windows protected your PC"</strong> warning when you open the installer.
+        </p>
+        <div class="steps">
+          <div class="step-item">
+            <span class="step-number">1</span>
+            <p>Click <strong>More info</strong> on the warning screen.</p>
+          </div>
+          <div class="step-item">
+            <span class="step-number">2</span>
+            <p>Click <strong>Run anyway</strong> to start the installer.</p>
+          </div>
+        </div>
+        <p class="source-link">
+          You can inspect our code transparently on <a href="https://github.com/Soumyadipgithub/SyncSpeak" target="_blank" rel="noopener">GitHub</a>.
+        </p>
+      </div>
+    </section>
+
     <section class="req glass-card">
       <h2>System requirements</h2>
       <dl>
@@ -235,6 +257,44 @@ npm run dev</code></pre>
   .asset-dl { padding: var(--space-s) var(--space-m); font-size: 0.875rem; }
 
   .empty { padding: var(--space-xl); text-align: center; }
+  .trusted-guide {
+    padding: var(--space-xl);
+    margin-bottom: var(--space-2xl);
+    border: 1px solid var(--accent-blue);
+    background: linear-gradient(180deg, rgba(10, 132, 255, 0.05) 0%, rgba(0, 0, 0, 0) 100%);
+  }
+  .trusted-guide h2 { margin-bottom: var(--space-s); color: var(--accent-blue); }
+  .trusted-guide p { margin-bottom: var(--space-l); font-size: 0.9375rem; color: var(--vibrant-label); }
+  .trusted-guide .steps {
+    display: flex;
+    gap: var(--space-l);
+    margin-bottom: var(--space-l);
+  }
+  .step-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-s);
+    background: var(--glass-panel);
+    padding: var(--space-s) var(--space-m);
+    border-radius: var(--radius-m);
+    border: 1px solid var(--border-glass);
+    flex: 1;
+  }
+  .step-item p { margin-bottom: 0; font-size: 0.875rem; color: var(--vibrant-primary); }
+  .step-number {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--accent-blue);
+    color: var(--black);
+    font-weight: bold;
+    font-size: 0.8125rem;
+  }
+  .source-link { font-size: 0.875rem; color: var(--vibrant-secondary); margin-bottom: 0 !important; }
+  .source-link a { color: var(--vibrant-primary); border-bottom: 1px solid var(--border-glass); }
 
   .req {
     padding: var(--space-xl);

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,7 +25,7 @@ const softwareJsonLd = {
   description,
   url: 'https://syncspeak.soumg.workers.dev',
   downloadUrl: 'https://github.com/Soumyadipgithub/SyncSpeak/releases/latest',
-  softwareVersion: '3.0.2',
+  softwareVersion: '3.0.3',
   license: 'https://opensource.org/licenses/MIT',
 };
 ---


### PR DESCRIPTION
## Release: v3.0.3

v3.0.3 — Branding & Trust Updates

## What's in this release

This release standardizes the official branding across the OS and provides clear instructions to help users bypass the Windows SmartScreen warning.

### Desktop app
- Fixed an issue where the Windows installer and application taskbar displayed the name as "SyncSpeak" instead of the official "Sync Speak" (with space).

### Website
- Added a new "Trusted & Open Source" installation guide to the `/download` page. This guide visually instructs users on how to click 'More info' and 'Run anyway' when the Windows SmartScreen warning appears, building trust for first-time users.

### CI / infra
- N/A

### Fixes
- #39 - Installer shows 'SyncSpeak' instead of 'Sync Speak'
- #40 - Add SmartScreen install guide to /download page

## Version bump

- [x] `package.json` updated
- [x] `src-tauri/tauri.conf.json` updated
- [x] `src-tauri/Cargo.toml` updated
- [x] `website/src/pages/index.astro` `softwareVersion` updated
- [x] `CHANGELOG.md` has a new entry for this version
- [ ] `docs/architecture.md` version reference updated (if changed)

## Pre-release checks

- [x] Tested desktop app end-to-end with `npm run dev` — translation pipeline works
- [x] Tested website preview URL (copy from Version History) — all 9 pages load
- [x] No personal data / credentials / TODOs leaked in the diff
- [x] No file over 5 MB in the diff
- [x] All required CI jobs pass (branch-name skipped intentionally for develop→main)
- [x] Sitemap still lists all pages correctly
- [x] Links in README and docs still valid

## Rollout plan

1. Merge this PR → `main` updates
2. Cloudflare auto-deploys website to `syncspeak.soumg.workers.dev` (~1 min)
3. GitHub Actions builds desktop binaries and publishes to GitHub Releases (manual trigger if needed)
4. Create git tag: `git tag v3.0.3 && git push --tags`
5. Open the sync-back PR: `main → develop` to keep develop in sync

## Smoke tests (after merge, before announcing)

- [ ] Open `https://syncspeak.soumg.workers.dev` — home page loads, version shows correctly
- [ ] `/features`, `/how-it-works`, `/download`, `/faq`, `/developers`, `/docs`, `/privacy` all load
- [ ] Download button on `/download` points at the latest GitHub release
- [ ] `robots.txt` accessible, `sitemap-index.xml` accessible
- [ ] Desktop app binary runs on a clean machine (or verified via a tester)

## Rollback plan

- **Website**: Cloudflare → Workers → Deployments → click previous version → **Promote to production** (≤1 min)
- **Desktop app**: previous release binaries remain on GitHub Releases — users can re-download
- **Config / APIs**: no server-side state to revert; each user has their own local config

## Announcement (post-merge)

- [ ] Update GitHub repo **Releases** page with CHANGELOG notes
- [ ] Pin release PR comment: "This version is live at syncspeak.soumg.workers.dev"
- [ ] Optional: social post / launch announcement
