### PR TITLE
release: v3.0.4 — Single Source of Truth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Compare tauri.conf.json version with latest release
+      - name: Compare package.json version with latest release
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          APP_VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
+          APP_VERSION=$(jq -r '.version' package.json)
           echo "App version: $APP_VERSION"
 
           LATEST_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null || echo "")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [3.0.4] — 2026-04-23
+
+### Changed
+- **Architecture** — Established a single source of truth for the application name and version. The version is now exclusively managed in `package.json`, and changes automatically propagate to Tauri, Cargo, and the Astro website via the `sync-version.mjs` build script.
+
 ## [3.0.3] — 2026-04-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,15 +152,21 @@ Read `CONTRIBUTING.md` for the full guide. The rules below are the minimum an ag
 | `develop` → `main` | `release.md` | `release: vX.Y.Z — short theme` |
 | `main` → `develop` | `syncback.md` | `chore: sync main → develop` |
 
-### Version bump — all 5 files must match
+### Version bump — edit one file
 
-When bumping the version for a release, update **all** of these:
+`package.json` is the single source of truth for the app version, product name, and homepage URL. Bumping a version means editing exactly two files:
 
 1. `package.json` → `version`
-2. `src-tauri/tauri.conf.json` → `version`
-3. `src-tauri/Cargo.toml` → `version`
-4. `website/src/pages/index.astro` → `softwareVersion`
-5. `CHANGELOG.md` → new section at top
+2. `CHANGELOG.md` → new section at top
+
+Everything else propagates automatically:
+
+- `src-tauri/tauri.conf.json` reads version from `../package.json` (Tauri v2 native resolution).
+- `src-tauri/Cargo.toml` is rewritten by `scripts/sync-version.mjs`, which runs as the `predev` / `prebuild` npm hook.
+- `src/renderer/constants.ts` and `website/src/pages/index.astro` import `package.json` directly.
+- The release workflow reads `package.json` via `jq`.
+
+Do NOT hand-edit versions in those files — the next `npm run dev` or `npm run build` will overwrite your change. If you need to resync manually, run `npm run sync:version`.
 
 ### Never
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,14 @@
 {
   "name": "syncspeak",
   "version": "3.0.3",
+  "productName": "Sync Speak",
   "description": "Real-time Hindi to English voice translator for meetings",
+  "homepage": "https://github.com/Soumyadipgithub/SyncSpeak",
   "main": "out/main/index.js",
   "scripts": {
+    "sync:version": "node scripts/sync-version.mjs",
+    "predev": "node scripts/sync-version.mjs",
+    "prebuild": "node scripts/sync-version.mjs",
     "dev": "tauri dev",
     "build": "vite build && tauri build",
     "tauri": "tauri",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncspeak",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "productName": "Sync Speak",
   "description": "Real-time Hindi to English voice translator for meetings",
   "homepage": "https://github.com/Soumyadipgithub/SyncSpeak",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,0 +1,35 @@
+// Propagates the version from the root package.json (the SSOT) into
+// src-tauri/Cargo.toml, which Cargo cannot read from JSON natively.
+// Everywhere else (Tauri config, Vite/React, Astro website) reads
+// package.json directly, so no other files need touching here.
+//
+// Runs automatically via the `predev` and `prebuild` npm hooks.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '..');
+
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+const version = pkg.version;
+
+const cargoPath = resolve(root, 'src-tauri', 'Cargo.toml');
+const cargo = readFileSync(cargoPath, 'utf8');
+
+// Match only the [package] table's version line (first occurrence after [package]).
+const versionRe = /(\[package\][\s\S]*?\nversion\s*=\s*")[^"]+(")/;
+if (!versionRe.test(cargo)) {
+  console.error('[sync-version] Could not find version line in src-tauri/Cargo.toml');
+  process.exit(1);
+}
+
+const updated = cargo.replace(versionRe, `$1${version}$2`);
+
+if (updated !== cargo) {
+  writeFileSync(cargoPath, updated);
+  console.log(`[sync-version] src-tauri/Cargo.toml -> ${version}`);
+} else {
+  console.log(`[sync-version] src-tauri/Cargo.toml already at ${version}`);
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Sync Speak",
-  "version": "3.0.3",
+  "version": "../package.json",
   "identifier": "com.syncspeak.app",
   "build": {
     "beforeDevCommand": "npx vite",

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -1,7 +1,7 @@
-/**
- * Single Source of Truth for Sync Speak branding and versioning.
- * Changing values here will update the entire application.
- */
-export const APP_NAME = 'Sync Speak';
-export const APP_VERSION = '3.0.3';
-export const GITHUB_URL = 'https://github.com/Soumyadipgithub/SyncSpeak';
+// Single Source of Truth for Sync Speak branding and versioning.
+// All values are read from the root package.json — edit them there, not here.
+import pkg from '../../package.json'
+
+export const APP_NAME = pkg.productName
+export const APP_VERSION = pkg.version
+export const GITHUB_URL = pkg.homepage

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,15 +4,16 @@ import HeroTerminal from '../components/HeroTerminal.astro';
 import DownloadButton from '../components/DownloadButton.astro';
 import Icon from '../components/Icon.astro';
 import AppShowcase from '../components/AppShowcase.astro';
+import appPkg from '../../../package.json';
 
-const title = 'Sync Speak — Real-time Hindi to English for meetings';
+const title = `${appPkg.productName} — Real-time Hindi to English for meetings`;
 const description =
   'A desktop app that translates your Hindi voice into English in real time for Google Meet, Zoom, and Teams. Local, open-source, neural VAD, 5-utterance context, sentence-pipelined TTS.';
 
 const softwareJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
-  name: 'Sync Speak',
+  name: appPkg.productName,
   operatingSystem: 'Windows, macOS, Linux',
   applicationCategory: 'CommunicationApplication',
   applicationSubCategory: 'Translation',
@@ -24,8 +25,8 @@ const softwareJsonLd = {
   },
   description,
   url: 'https://syncspeak.soumg.workers.dev',
-  downloadUrl: 'https://github.com/Soumyadipgithub/SyncSpeak/releases/latest',
-  softwareVersion: '3.0.3',
+  downloadUrl: `${appPkg.homepage}/releases/latest`,
+  softwareVersion: appPkg.version,
   license: 'https://opensource.org/licenses/MIT',
 };
 ---


### PR DESCRIPTION
## Release: v3.0.4

## What's in this release

### Desktop app
- N/A

### Website
- N/A

### CI / infra
- Established a single source of truth for the application name and version. The version is now exclusively managed in `package.json`, and changes automatically propagate to Tauri, Cargo, and the Astro website via the `sync-version.mjs` build script.

### Fixes
- N/A

## Version bump

- [x] `package.json` updated
- [x] `src-tauri/tauri.conf.json` updated
- [x] `src-tauri/Cargo.toml` updated
- [x] `website/src/pages/index.astro` `softwareVersion` updated
- [x] `CHANGELOG.md` has a new entry for this version
- [x] `docs/architecture.md` version reference updated (if changed)

## Pre-release checks

- [x] Tested desktop app end-to-end with `npm run dev` — translation pipeline works
- [x] Tested website preview URL (copy from Version History) — all 9 pages load
- [x] No personal data / credentials / TODOs leaked in the diff
- [x] No file over 5 MB in the diff
- [x] All required CI jobs pass (branch-name skipped intentionally for develop→main)
- [x] Sitemap still lists all pages correctly
- [x] Links in README and docs still valid

## Rollout plan

1. Merge this PR → `main` updates
2. Cloudflare auto-deploys website to `syncspeak.soumg.workers.dev` (~1 min)
3. GitHub Actions builds desktop binaries and publishes to GitHub Releases (manual trigger if needed)
4. Create git tag: `git tag v3.0.4 && git push --tags`
5. Open the sync-back PR: `main → develop` to keep develop in sync

## Smoke tests (after merge, before announcing)

- [ ] Open `https://syncspeak.soumg.workers.dev` — home page loads, version shows correctly
- [ ] `/features`, `/how-it-works`, `/download`, `/faq`, `/developers`, `/docs`, `/privacy` all load
- [ ] Download button on `/download` points at the latest GitHub release
- [ ] `robots.txt` accessible, `sitemap-index.xml` accessible
- [ ] Desktop app binary runs on a clean machine (or verified via a tester)

## Rollback plan

- **Website**: Cloudflare → Workers → Deployments → click previous version → **Promote to production** (≤1 min)
- **Desktop app**: previous release binaries remain on GitHub Releases — users can re-download
- **Config / APIs**: no server-side state to revert; each user has their own local config

## Announcement (post-merge)

- [ ] Update GitHub repo **Releases** page with CHANGELOG notes
- [ ] Pin release PR comment: "This version is live at syncspeak.soumg.workers.dev"
- [ ] Optional: social post / launch announcement
