### PR TITLE
chore: bump version to v3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [3.0.5] — 2026-04-23
+
+### Added
+- **Auto Updater** — Implemented a silent background auto-updater using Tauri plugins (`tauri-plugin-updater` and `tauri-plugin-process`). Updates are checked and downloaded in the background. Once an update is ready, a seamless "Liquid Glass" restart prompt appears in the bottom right corner without interrupting active translation.
+
 ## [3.0.4] — 2026-04-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncspeak",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "productName": "Sync Speak",
   "description": "Real-time Hindi to English voice translator for meetings",
   "homepage": "https://github.com/Soumyadipgithub/SyncSpeak",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncspeak"
-version = "3.0.4"
+version = "3.0.5"
 description = "Real-time Hindi to English voice translator for meetings"
 authors = ["Soumyadip Giri"]
 license = "MIT"


### PR DESCRIPTION
## What this PR does

This PR safely bumps the application version to 3.0.5 as a staging step before the official release to `main`. It updates `package.json` and `CHANGELOG.md`, and runs the `sync:version` script to propagate the version bump to Tauri and the Rust backend.

## How to test

1. Review the `package.json` to ensure the version is `3.0.5`.
2. Check `src-tauri/Cargo.toml` to ensure it successfully synced to `3.0.5`.
3. Check `CHANGELOG.md` to ensure the new Auto Updater notes are present.

## Checklist

- [x] Branch targets `develop` (not `main`)
- [x] Branch name follows the naming convention (see CONTRIBUTING.md)
- [x] Read [CLAUDE.md](../CLAUDE.md) before making changes
- [x] Behaviour is unchanged or the change is intentional and described above
- [x] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback
- [x] Glass design rules followed (no solid backgrounds, no Tailwind)
- [x] No hardcoded API keys, paths, or credentials
- [x] Tested manually with `npm run dev`

## Screenshots (if UI changed)

*(No UI changes, version bump only)*
