### PR TITLE
feat: v3.0.6 — security hardening and CSP isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [3.0.6] — 2026-04-23
+
+### Added
+- **Security hardening** — Implemented a strict Content Security Policy (CSP) in `tauri.conf.json`. This defense-in-depth measure isolates the frontend from the open internet, preventing XSS-based data exfiltration.
+
 ## [3.0.5] — 2026-04-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncspeak",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "productName": "Sync Speak",
   "description": "Real-time Hindi to English voice translator for meetings",
   "homepage": "https://github.com/Soumyadipgithub/SyncSpeak",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "syncspeak"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "syncspeak"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncspeak"
-version = "3.0.5"
+version = "3.0.6"
 description = "Real-time Hindi to English voice translator for meetings"
 authors = ["Soumyadip Giri"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost;"
     }
   },
   "bundle": {


### PR DESCRIPTION
## What this PR does

This PR implements security hardening and bumps the application version to **v3.0.6**.

### Key Changes:
- **Strict Content Security Policy (CSP)**: Added a robust CSP to `tauri.conf.json` that isolates the frontend from the open internet. This ensures that even in the event of an XSS vulnerability, sensitive data like API keys cannot be exfiltrated to unauthorized domains.
- **Version Bump**: Updated version to `3.0.6` across `package.json`, `Cargo.toml`, and `CHANGELOG.md`.

## How to test

1. Run `npm run dev` and ensure the application launches correctly.
2. Check the browser console to ensure no unexpected CSP violations are blocking core functionality (Tauri IPC and local assets should be allowed).
3. Verify that the UI still communicates with the Python sidecar and that translations work as expected.

## Checklist

- [x] Branch targets `develop` (not `main`)
- [x] Branch name follows the naming convention (see CONTRIBUTING.md)
- [x] Read [CLAUDE.md](../CLAUDE.md) before making changes
- [x] Behaviour is unchanged or the change is intentional and described above
- [x] Key behaviours are not broken: TTS feedback flag, VAD pre-buffer, WASAPI reinit, device fallback
- [x] Glass design rules followed (no solid backgrounds, no Tailwind)
- [x] No hardcoded API keys, paths, or credentials
- [x] Tested manually with `npm run dev`
