### PR TITLE
release: v3.0.6 — Security hardening and CSP isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [3.0.6] — 2026-04-23
+
+### Added
+- **Security hardening** — Implemented a strict Content Security Policy (CSP) in `tauri.conf.json`. This defense-in-depth measure isolates the frontend from the open internet, preventing XSS-based data exfiltration.
+
 ## [3.0.5] — 2026-04-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncspeak",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "productName": "Sync Speak",
   "description": "Real-time Hindi to English voice translator for meetings",
   "homepage": "https://github.com/Soumyadipgithub/SyncSpeak",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "syncspeak"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "syncspeak"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncspeak"
-version = "3.0.5"
+version = "3.0.6"
 description = "Real-time Hindi to English voice translator for meetings"
 authors = ["Soumyadip Giri"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost;"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Release: v3.0.6

Security hardening and version bump.

## What's in this release

### Desktop app
- **Security hardening**: Implemented a strict Content Security Policy (CSP) to isolate the frontend from the open internet, preventing potential data exfiltration (#62).
- **Version bump**: Updated application to v3.0.6.

### CI / infra
- All CI jobs passed on `develop` before merging.

## Version bump

- [x] `package.json` updated
- [x] `src-tauri/tauri.conf.json` updated
- [x] `src-tauri/Cargo.toml` updated
- [x] `website/src/pages/index.astro` `softwareVersion` updated
- [x] `CHANGELOG.md` has a new entry for this version
- [ ] `docs/architecture.md` version reference updated (if changed)

## Pre-release checks

- [x] Tested desktop app end-to-end with `npm run dev` — translation pipeline works
- [x] No personal data / credentials / TODOs leaked in the diff
- [x] No file over 5 MB in the diff
- [x] All required CI jobs pass (branch-name skipped intentionally for develop→main)
